### PR TITLE
Update pom.xml

### DIFF
--- a/costcategory/pom.xml
+++ b/costcategory/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>1.0.3</version>
+            <version>2.0.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->


### PR DESCRIPTION
aws-cloudformation-rpdk-java-plugin 1.0.3  is no longer supported, updated to the last version 2.0.1


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
