### PR TITLE
Contract test

### DIFF
--- a/costcategory/.gitignore
+++ b/costcategory/.gitignore
@@ -15,6 +15,7 @@ out/
 
 # auto-generated files
 target/
+.hypothesis
 
 # our logs
 rpdk.log

--- a/costcategory/.gitignore
+++ b/costcategory/.gitignore
@@ -16,6 +16,7 @@ out/
 # auto-generated files
 target/
 .hypothesis
+docs/README.md
 
 # our logs
 rpdk.log

--- a/costcategory/inputs/inputs_1_create.json
+++ b/costcategory/inputs/inputs_1_create.json
@@ -1,0 +1,5 @@
+{
+  "Name": "ContractTestCC",
+  "RuleVersion": "CostCategoryExpression.v1",
+  "Rules": "[ {\n  \"Value\" : \"Engineering\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  }\n} ]"
+}

--- a/costcategory/inputs/inputs_1_invalid.json
+++ b/costcategory/inputs/inputs_1_invalid.json
@@ -1,0 +1,5 @@
+{
+  "Name": "ContractTestCC",
+  "RuleVersion": "CostCategoryExpression.v1",
+  "Rules": ""
+}

--- a/costcategory/inputs/inputs_1_invalid.json
+++ b/costcategory/inputs/inputs_1_invalid.json
@@ -1,4 +1,5 @@
 {
+  "Arn": "arn:aws:ce::494077034435:costcategory/123",
   "Name": "ContractTestCC",
   "RuleVersion": "CostCategoryExpression.v1",
   "Rules": ""

--- a/costcategory/inputs/inputs_1_update.json
+++ b/costcategory/inputs/inputs_1_update.json
@@ -1,0 +1,4 @@
+{
+  "RuleVersion": "CostCategoryExpression.v1",
+  "Rules": "[ {\n  \"Value\" : \"Dev\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  }\n} ]"
+}

--- a/costcategory/pom.xml
+++ b/costcategory/pom.xml
@@ -30,14 +30,14 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.13.4</version>
+            <version>2.14.28</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/DeleteHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/DeleteHandler.java
@@ -1,6 +1,7 @@
 package software.amazon.ce.costcategory;
 
 import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -28,12 +29,10 @@ public class DeleteHandler extends CostCategoryBaseHandler {
                     costExplorerClient::deleteCostCategoryDefinition
             );
         } catch (ResourceNotFoundException ex) {
-            // If resource has already been deleted outside stack, skip deletion and mark it success.
-            logger.log(String.format("Cost category %s does not exist, skip deletion.", model.getArn()));
+            throw new CfnNotFoundException(ex);
         }
 
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
             .status(OperationStatus.SUCCESS)
             .build();
     }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
@@ -2,6 +2,8 @@ package software.amazon.ce.costcategory;
 
 import software.amazon.awssdk.services.costexplorer.model.CostCategory;
 import software.amazon.awssdk.services.costexplorer.model.DescribeCostCategoryDefinitionResponse;
+import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -23,20 +25,24 @@ public class ReadHandler extends CostCategoryBaseHandler {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        DescribeCostCategoryDefinitionResponse response = proxy.injectCredentialsAndInvokeV2(
-                CostCategoryRequestBuilder.buildDescribeRequest(model),
-                costExplorerClient::describeCostCategoryDefinition
-        );
+        try {
+            DescribeCostCategoryDefinitionResponse response = proxy.injectCredentialsAndInvokeV2(
+                    CostCategoryRequestBuilder.buildDescribeRequest(model),
+                    costExplorerClient::describeCostCategoryDefinition
+            );
 
-        CostCategory costCategory = response.costCategory();
-        model.setName(costCategory.name());
-        model.setEffectiveStart(costCategory.effectiveStart());
-        model.setRuleVersion(costCategory.ruleVersionAsString());
-        model.setRules(CostCategoryRulesParser.toJson(costCategory.rules()));
+            CostCategory costCategory = response.costCategory();
+            model.setName(costCategory.name());
+            model.setEffectiveStart(costCategory.effectiveStart());
+            model.setRuleVersion(costCategory.ruleVersionAsString());
+            model.setRules(CostCategoryRulesParser.toJson(costCategory.rules()));
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.SUCCESS)
+                    .build();
+        } catch (ResourceNotFoundException ex) {
+            throw new CfnNotFoundException(ex);
+        }
     }
 }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/UpdateHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/UpdateHandler.java
@@ -1,5 +1,7 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -20,14 +22,18 @@ public class UpdateHandler extends CostCategoryBaseHandler {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        proxy.injectCredentialsAndInvokeV2(
-                CostCategoryRequestBuilder.buildUpdateRequest(model),
-                costExplorerClient::updateCostCategoryDefinition
-        );
+        try {
+            proxy.injectCredentialsAndInvokeV2(
+                    CostCategoryRequestBuilder.buildUpdateRequest(model),
+                    costExplorerClient::updateCostCategoryDefinition
+            );
 
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .resourceModel(model)
-            .status(OperationStatus.SUCCESS)
-            .build();
+            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                    .resourceModel(model)
+                    .status(OperationStatus.SUCCESS)
+                    .build();
+        } catch (ResourceNotFoundException ex) {
+            throw new CfnNotFoundException(ex);
+        }
     }
 }

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
@@ -3,6 +3,7 @@ package software.amazon.ce.costcategory
 import software.amazon.awssdk.services.costexplorer.model.DeleteCostCategoryDefinitionRequest
 import software.amazon.awssdk.services.costexplorer.model.DeleteCostCategoryDefinitionResponse
 import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException
+import software.amazon.cloudformation.exceptions.CfnNotFoundException
 import software.amazon.cloudformation.proxy.OperationStatus
 
 import static software.amazon.ce.costcategory.Fixtures.*
@@ -29,7 +30,7 @@ class DeleteHandlerTest extends HandlerSpecification {
         }
 
         event.status == OperationStatus.SUCCESS
-        event.resourceModel == model
+        event.resourceModel == null
     }
 
     def "Test: handleRequest success when resource has already been deleted"() {
@@ -42,12 +43,10 @@ class DeleteHandlerTest extends HandlerSpecification {
         }
 
         when:
-        def event = handler.handleRequest(proxy, request, callbackContext, logger)
+        handler.handleRequest(proxy, request, callbackContext, logger)
 
         then:
         1 * request.getDesiredResourceState() >> model
-
-        event.status == OperationStatus.SUCCESS
-        event.resourceModel == model
+        thrown CfnNotFoundException
     }
 }

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
@@ -33,7 +33,7 @@ class DeleteHandlerTest extends HandlerSpecification {
         event.resourceModel == null
     }
 
-    def "Test: handleRequest success when resource has already been deleted"() {
+    def "Test: handleRequest throws CfnNotFoundException when resource has already been deleted"() {
         given:
         def model = ResourceModel.builder()
                 .arn(COST_CATEGORY_ARN)

--- a/costcategory/template.yml
+++ b/costcategory/template.yml
@@ -13,6 +13,7 @@ Resources:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::handleRequest
       Runtime: java8
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
+      MemorySize: 512
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
@@ -20,3 +21,4 @@ Resources:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::testEntrypoint
       Runtime: java8
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
+      MemorySize: 512


### PR DESCRIPTION
*Description of changes:*

- Add contract tests input based on [doc](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test.html)
- Fix contract tests failures:
- - Return NotFound CFN code instead of CostExplore NotFound error when read/update/delete
- - Do not return the deleted resource in the model of response
- Also upgrade dependencies and ignore the auto generated README during build.
- Set lambda `MemorySize` to 512M so we don't have contract tests failure of OutOfMemory error.


Here is the contract tests results:

```
[I]  ~/w/a/costcategory (contract-test)> cfn test --enforce-timeout 240
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.8.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1 -- /usr/local/opt/python@3.8/bin/python3.8
cachedir: .pytest_cache
Test order randomisation NOT enabled. Enable with --random-order or --random-order-bucket=<bucket_type>
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Volumes/workplace/aws-cloudformation-resource-providers-cost-explorer/costcategory/.hypothesis/examples')
rootdir: /Volumes/workplace/aws-cloudformation-resource-providers-cost-explorer/costcategory, configfile: ../../../../private/var/folders/lf/v45zb8cs4vvgs_svdblm66d0dvchqx/T/pytest_wbq9kxsm.ini
plugins: localserver-0.5.0, random-order-1.0.4, hypothesis-5.37.3
collected 16 items

handler_create.py::contract_create_delete PASSED                                                                                                       [  6%]
handler_create.py::contract_invalid_create PASSED                                                                                                      [ 12%]
handler_create.py::contract_create_duplicate SKIPPED                                                                                                   [ 18%]
handler_create.py::contract_create_read_success PASSED                                                                                                 [ 25%]
handler_create.py::contract_create_list_success PASSED                                                                                                 [ 31%]
handler_delete.py::contract_delete_read PASSED                                                                                                         [ 37%]
handler_delete.py::contract_delete_list PASSED                                                                                                         [ 43%]
handler_delete.py::contract_delete_update PASSED                                                                                                       [ 50%]
handler_delete.py::contract_delete_delete PASSED                                                                                                       [ 56%]
handler_delete.py::contract_delete_create SKIPPED                                                                                                      [ 62%]
handler_misc.py::contract_check_asserts_work PASSED                                                                                                    [ 68%]
handler_read.py::contract_read_without_create PASSED                                                                                                   [ 75%]
handler_update.py::contract_update_read_success PASSED                                                                                                 [ 81%]
handler_update.py::contract_update_list_success PASSED                                                                                                 [ 87%]
handler_update_invalid.py::contract_update_create_only_property PASSED                                                                                 [ 93%]
handler_update_invalid.py::contract_update_non_existent_resource PASSED                                                                                [100%]

========================================================= 14 passed, 2 skipped in 850.73s (0:14:10) ==========================================================
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
