### PR TITLE
upgrade CostExplorer sdk version to support cost category default value

### DIFF
--- a/costcategory/.rpdk-config
+++ b/costcategory/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::CostCategory",
     "language": "java",
     "runtime": "java8",
@@ -12,5 +13,6 @@
             "costcategory"
         ],
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.ce.costcategory.HandlerWrapperExecutable"
 }

--- a/costcategory/aws-ce-costcategory.json
+++ b/costcategory/aws-ce-costcategory.json
@@ -23,7 +23,7 @@
     "Name": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 255
+      "maxLength": 50
     },
     "RuleVersion": {
       "type": "string",
@@ -34,6 +34,12 @@
     "Rules": {
       "type": "string",
       "description": "JSON array format of Expression in Billing and Cost Management API"
+    },
+    "DefaultValue": {
+      "type": "string",
+      "description": "The default value for the cost category",
+      "minLength": 1,
+      "maxLength": 50
     }
   },
   "additionalProperties": false,

--- a/costcategory/pom.xml
+++ b/costcategory/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.14.28</version>
+            <version>2.16.30</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryRequestBuilder.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryRequestBuilder.java
@@ -13,6 +13,7 @@ public class CostCategoryRequestBuilder {
                 .name(model.getName())
                 .ruleVersion(model.getRuleVersion())
                 .rules(CostCategoryRulesParser.fromJson(model.getRules()))
+                .defaultValue(model.getDefaultValue())
                 .build();
     }
 
@@ -21,6 +22,7 @@ public class CostCategoryRequestBuilder {
                 .costCategoryArn(model.getArn())
                 .ruleVersion(model.getRuleVersion())
                 .rules(CostCategoryRulesParser.fromJson(model.getRules()))
+                .defaultValue(model.getDefaultValue())
                 .build();
     }
 

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryRulesParser.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryRulesParser.java
@@ -39,13 +39,15 @@ public class CostCategoryRulesParser {
 
         // SDK model has no default constructor, and build class is private.
         // Add custom builder so Jackson can deserialize the class.
-        final Map<Class<?>, Class<?>> buildersMap = ImmutableMap.of(
-                CostCategoryRule.class, CostCategoryRule.serializableBuilderClass(),
-                Expression.class, Expression.serializableBuilderClass(),
-                DimensionValues.class, DimensionValues.serializableBuilderClass(),
-                TagValues.class, TagValues.serializableBuilderClass(),
-                CostCategoryValues.class, CostCategoryValues.serializableBuilderClass()
-        );
+        final Map<Class<?>, Class<?>> buildersMap = ImmutableMap.<Class<?>, Class<?>>builder()
+                .put(CostCategoryRule.class, CostCategoryRule.serializableBuilderClass())
+                .put(Expression.class, Expression.serializableBuilderClass())
+                .put(DimensionValues.class, DimensionValues.serializableBuilderClass())
+                .put(TagValues.class, TagValues.serializableBuilderClass())
+                .put(CostCategoryValues.class, CostCategoryValues.serializableBuilderClass())
+                .put(CostCategoryInheritedValueDimension.class, CostCategoryInheritedValueDimension.serializableBuilderClass())
+                .build();
+
         OBJECT_MAPPER.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
             private static final long serialVersionUID = 1L;
 

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/CostCategoryRulesParserTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/CostCategoryRulesParserTest.groovy
@@ -18,13 +18,14 @@ class CostCategoryRulesParserTest extends Specification {
         jsonArray == "[ ${expectedJson} ]"
 
         where:
-        expectedJson            | rule
-        JSON_RULE_DIMENSION     | RULE_DIMENSION
-        JSON_RULE_TAG           | RULE_TAG
-        JSON_RULE_COST_CATEGORY | RULE_COST_CATEGORY
-        JSON_RULE_AND           | RULE_AND
-        JSON_RULE_OR            | RULE_OR
-        JSON_RULE_NOT           | RULE_NOT
+        expectedJson              | rule
+        JSON_RULE_DIMENSION       | RULE_DIMENSION
+        JSON_RULE_TAG             | RULE_TAG
+        JSON_RULE_COST_CATEGORY   | RULE_COST_CATEGORY
+        JSON_RULE_AND             | RULE_AND
+        JSON_RULE_OR              | RULE_OR
+        JSON_RULE_NOT             | RULE_NOT
+        JSON_RULE_INHERITED_VALUE | RULE_INHERITED_VALUE
     }
 
     @Unroll
@@ -36,13 +37,14 @@ class CostCategoryRulesParserTest extends Specification {
         rules == [expectedRule]
 
         where:
-        json                    | expectedRule
-        JSON_RULE_DIMENSION     | RULE_DIMENSION
-        JSON_RULE_TAG           | RULE_TAG
-        JSON_RULE_COST_CATEGORY | RULE_COST_CATEGORY
-        JSON_RULE_AND           | RULE_AND
-        JSON_RULE_OR            | RULE_OR
-        JSON_RULE_NOT           | RULE_NOT
+        json                      | expectedRule
+        JSON_RULE_DIMENSION       | RULE_DIMENSION
+        JSON_RULE_TAG             | RULE_TAG
+        JSON_RULE_COST_CATEGORY   | RULE_COST_CATEGORY
+        JSON_RULE_AND             | RULE_AND
+        JSON_RULE_OR              | RULE_OR
+        JSON_RULE_NOT             | RULE_NOT
+        JSON_RULE_INHERITED_VALUE | RULE_INHERITED_VALUE
     }
 
     def "Test: fromJson for invalid json"() {

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
@@ -20,7 +20,7 @@ class CreateHandlerTest extends HandlerSpecification {
         def model = ResourceModel.builder()
                 .name(COST_CATEGORY_NAME)
                 .ruleVersion(RULE_VERSION)
-                .rules("[ ${JSON_RULE_DIMENSION} ]")
+                .rules("[ ${JSON_RULE_DIMENSION}, ${JSON_RULE_INHERITED_VALUE} ]")
                 .defaultValue(COST_CATEGORY_DEFAULT_VALUE)
                 .build()
 
@@ -32,7 +32,7 @@ class CreateHandlerTest extends HandlerSpecification {
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { CreateCostCategoryDefinitionRequest createRequest, _ ->
             assert createRequest.name() == model.name
             assert createRequest.ruleVersionAsString() == model.ruleVersion
-            assert createRequest.rules() == [ RULE_DIMENSION ]
+            assert createRequest.rules() == [ RULE_DIMENSION, RULE_INHERITED_VALUE ]
             assert createRequest.defaultValue() == COST_CATEGORY_DEFAULT_VALUE
             createResponse
         }

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
@@ -21,6 +21,7 @@ class CreateHandlerTest extends HandlerSpecification {
                 .name(COST_CATEGORY_NAME)
                 .ruleVersion(RULE_VERSION)
                 .rules("[ ${JSON_RULE_DIMENSION} ]")
+                .defaultValue(COST_CATEGORY_DEFAULT_VALUE)
                 .build()
 
         when:
@@ -29,10 +30,10 @@ class CreateHandlerTest extends HandlerSpecification {
         then:
         1 * request.getDesiredResourceState() >> model
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { CreateCostCategoryDefinitionRequest createRequest, _ ->
-            createRequest.name() == model.name
-            createRequest.ruleVersionAsString() == model.ruleVersion
-            createRequest.rules() == [ RULE_DIMENSION ]
-
+            assert createRequest.name() == model.name
+            assert createRequest.ruleVersionAsString() == model.ruleVersion
+            assert createRequest.rules() == [ RULE_DIMENSION ]
+            assert createRequest.defaultValue() == COST_CATEGORY_DEFAULT_VALUE
             createResponse
         }
 

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
@@ -25,7 +25,7 @@ class DeleteHandlerTest extends HandlerSpecification {
         then:
         1 * request.getDesiredResourceState() >> model
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { DeleteCostCategoryDefinitionRequest deleteRequest, _  ->
-            deleteRequest.costCategoryArn() == model.arn
+            assert deleteRequest.costCategoryArn() == model.arn
             deleteResponse
         }
 

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory
 
+import software.amazon.awssdk.services.costexplorer.model.CostCategoryInheritedValueDimension
 import software.amazon.awssdk.services.costexplorer.model.CostCategoryRule
 import software.amazon.awssdk.services.costexplorer.model.CostCategoryValues
 import software.amazon.awssdk.services.costexplorer.model.DimensionValues
@@ -151,4 +152,19 @@ class Fixtures {
     static final CostCategoryRule RULE_NOT = CostCategoryRule.builder()
             .value("Not")
             .rule(EXPRESSION_NOT).build()
+
+    static final String JSON_RULE_INHERITED_VALUE = '''{
+  "Type" : "INHERITED_VALUE",
+  "InheritedValue" : {
+      "DimensionName" : "TAG",
+      "DimensionKey" : "DevUsage"
+  }
+}'''
+
+    static final CostCategoryInheritedValueDimension INHERITED_VALUE_DIMENSION = CostCategoryInheritedValueDimension.builder()
+            .dimensionName("TAG").dimensionKey("DevUsage").build();
+
+    static final CostCategoryRule RULE_INHERITED_VALUE = CostCategoryRule.builder()
+            .type("INHERITED_VALUE").inheritedValue(INHERITED_VALUE_DIMENSION).build();
+
 }

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
@@ -154,11 +154,11 @@ class Fixtures {
             .rule(EXPRESSION_NOT).build()
 
     static final String JSON_RULE_INHERITED_VALUE = '''{
-  "Type" : "INHERITED_VALUE",
   "InheritedValue" : {
-      "DimensionName" : "TAG",
-      "DimensionKey" : "DevUsage"
-  }
+    "DimensionName" : "TAG",
+    "DimensionKey" : "DevUsage"
+  },
+  "Type" : "INHERITED_VALUE"
 }'''
 
     static final CostCategoryInheritedValueDimension INHERITED_VALUE_DIMENSION = CostCategoryInheritedValueDimension.builder()

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/Fixtures.groovy
@@ -16,6 +16,7 @@ class Fixtures {
 
     static final COST_CATEGORY_EFFECTIVE_START = "2019-05-01T00:00:00Z"
 
+    static final COST_CATEGORY_DEFAULT_VALUE = "DefaultValue"
 
     static final JSON_RULE_DIMENSION = '''{
   "Value" : "Dimension",

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ListHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ListHandlerTest.groovy
@@ -37,7 +37,7 @@ class ListHandlerTest extends HandlerSpecification {
         1 * request.getNextToken() >> nextToken
 
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { ListCostCategoryDefinitionsRequest listRequest, _ ->
-            listRequest.nextToken() == nextToken
+            assert listRequest.nextToken() == nextToken
             listResponse
         }
 

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
@@ -33,7 +33,7 @@ class ReadHandlerTest extends HandlerSpecification {
         then:
         1 * request.getDesiredResourceState() >> model
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { DescribeCostCategoryDefinitionRequest describeRequest, _ ->
-            describeRequest.costCategoryArn() == model.arn
+            assert describeRequest.costCategoryArn() == model.arn
             describeResponse
         }
 

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
@@ -34,6 +34,7 @@ class UpdateHandlerTest extends HandlerSpecification {
             assert updateRequest.costCategoryArn() == COST_CATEGORY_ARN
             assert updateRequest.ruleVersionAsString() == RULE_VERSION
             assert updateRequest.rules() == [ RULE_DIMENSION ]
+            assert updateRequest.defaultValue() == COST_CATEGORY_DEFAULT_VALUE
 
             updateResponse
         }

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
@@ -18,9 +18,11 @@ class UpdateHandlerTest extends HandlerSpecification {
             .build()
 
         def model = ResourceModel.builder()
+            .arn(COST_CATEGORY_ARN)
             .name(COST_CATEGORY_NAME)
             .ruleVersion(RULE_VERSION)
             .rules("[ ${JSON_RULE_DIMENSION} ]")
+            .defaultValue(COST_CATEGORY_DEFAULT_VALUE)
             .build()
 
         when:
@@ -29,9 +31,9 @@ class UpdateHandlerTest extends HandlerSpecification {
         then:
         1 * request.getDesiredResourceState() >> model
         1 * proxy.injectCredentialsAndInvokeV2(*_) >> { UpdateCostCategoryDefinitionRequest updateRequest, _ ->
-            updateRequest.costCategoryArn() == COST_CATEGORY_ARN
-            updateRequest.ruleVersionAsString() == RULE_VERSION
-            updateRequest.rules() == [ RULE_DIMENSION ]
+            assert updateRequest.costCategoryArn() == COST_CATEGORY_ARN
+            assert updateRequest.ruleVersionAsString() == RULE_VERSION
+            assert updateRequest.rules() == [ RULE_DIMENSION ]
 
             updateResponse
         }


### PR DESCRIPTION
Upgrade CostExplorer sdk version to support cost category default value

*Description of changes:*

1. upgrade CE sdk version to support  latest cost category API
2. add new property "DefautlValue" in `aws-ce-costcategory.json` 
3. unit test update cover `DefaultValue`
4. fix limitation for cost category "Name" to be maximum 50
5. fix to use explicit `assert` in Groovy closure, otherwise it does not report failure 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
