### PR TITLE
Update Cost Categories handler to work in all regions within supported partitions

### DIFF
--- a/costcategory/inputs/inputs_1_create.json
+++ b/costcategory/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
   "Name": "ContractTestCC",
   "RuleVersion": "CostCategoryExpression.v1",
-  "Rules": "[ {\n  \"Value\" : \"Engineering\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  }\n} ]"
+  "Rules": "[ {\n  \"Value\" : \"Engineering\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n} ]"
 }

--- a/costcategory/inputs/inputs_1_update.json
+++ b/costcategory/inputs/inputs_1_update.json
@@ -1,4 +1,5 @@
 {
+  "Name": "ContractTestCC",
   "RuleVersion": "CostCategoryExpression.v1",
-  "Rules": "[ {\n  \"Value\" : \"Dev\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  }\n} ]"
+  "Rules": "[ {\n  \"Value\" : \"Dev\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n} ]"
 }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryBaseHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryBaseHandler.java
@@ -2,10 +2,14 @@ package software.amazon.ce.costcategory;
 
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.utils.AttributeMap;
+import software.amazon.awssdk.utils.ImmutableMap;
 
 import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Base class for cost category resource handler.
@@ -21,6 +25,13 @@ public abstract class CostCategoryBaseHandler extends BaseHandler<CallbackContex
 
     protected final CostExplorerClient costExplorerClient;
 
+    // Cost Categories is global in partition. Thus, in order to choose the global region when constructing the client,
+    // we need to have this map from partition to global region
+    protected static Map<String, Region> partitionToGlobalRegionMap = ImmutableMap.of(
+            Region.CN_NORTH_1.metadata().partition().name(), Region.AWS_CN_GLOBAL,
+            Region.US_EAST_1.metadata().partition().name(), Region.AWS_GLOBAL
+    );
+
     public CostCategoryBaseHandler() {
         AttributeMap httpOptions = AttributeMap.builder()
                 .put(SdkHttpConfigurationOption.READ_TIMEOUT, HTTP_READ_TIMEOUT)
@@ -28,6 +39,12 @@ public abstract class CostCategoryBaseHandler extends BaseHandler<CallbackContex
 
         this.costExplorerClient = CostExplorerClient.builder()
                 .httpClient(new DefaultSdkHttpClientBuilder().buildWithDefaults(httpOptions))
+                .region(partitionToGlobalRegionMap.get(
+                        Region.of(System.getenv("AWS_REGION")).metadata().partition().name()))
                 .build();
+    }
+
+    public CostCategoryBaseHandler(CostExplorerClient costExplorerClient) {
+        this.costExplorerClient = costExplorerClient;
     }
 }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CreateHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.CreateCostCategoryDefinitionResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
@@ -11,6 +12,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
  * CloudFormation invokes this handler when the resource is initially created during stack create operations.
  */
 public class CreateHandler extends CostCategoryBaseHandler {
+
+    public CreateHandler() {
+        super();
+    }
+
+    public CreateHandler(CostExplorerClient costExplorerClient) {
+        super(costExplorerClient);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/DeleteHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/DeleteHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -13,6 +14,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
  * either when the resource is deleted from the stack as part of a stack update operation, or the stack itself is deleted.
  */
 public class DeleteHandler extends CostCategoryBaseHandler {
+
+    public DeleteHandler() {
+        super();
+    }
+
+    public DeleteHandler(CostExplorerClient costExplorerClient) {
+        super(costExplorerClient);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/ListHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/ListHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.ListCostCategoryDefinitionsResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
@@ -14,6 +15,14 @@ import java.util.stream.Collectors;
  * CloudFormation invokes this handler when summary information about multiple resources of this resource provider is required.
  */
 public class ListHandler extends CostCategoryBaseHandler {
+
+    public ListHandler() {
+        super();
+    }
+
+    public ListHandler(CostExplorerClient costExplorerClient) {
+        super(costExplorerClient);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
@@ -36,6 +36,7 @@ public class ReadHandler extends CostCategoryBaseHandler {
             model.setEffectiveStart(costCategory.effectiveStart());
             model.setRuleVersion(costCategory.ruleVersionAsString());
             model.setRules(CostCategoryRulesParser.toJson(costCategory.rules()));
+            model.setDefaultValue(costCategory.defaultValue());
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()
                     .resourceModel(model)

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.CostCategory;
 import software.amazon.awssdk.services.costexplorer.model.DescribeCostCategoryDefinitionResponse;
 import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
@@ -15,6 +16,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
  * when detailed information about the resource's current state is required.
  */
 public class ReadHandler extends CostCategoryBaseHandler {
+
+    public ReadHandler() {
+        super();
+    }
+
+    public ReadHandler(CostExplorerClient costExplorerClient) {
+        super(costExplorerClient);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/UpdateHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/UpdateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory;
 
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.ResourceNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -12,6 +13,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
  * CloudFormation invokes this handler when the resource is updated as part of a stack update operation.
  */
 public class UpdateHandler extends CostCategoryBaseHandler {
+
+    public UpdateHandler() {
+        super();
+    }
+
+    public UpdateHandler(CostExplorerClient costExplorerClient) {
+        super(costExplorerClient);
+    }
 
     @Override
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/CreateHandlerTest.groovy
@@ -8,7 +8,7 @@ import static software.amazon.ce.costcategory.Fixtures.*
 
 class CreateHandlerTest extends HandlerSpecification {
 
-    def handler = new CreateHandler()
+    def handler = new CreateHandler(TestUtils.generateTestClient())
 
     def "Test: handleRequest"() {
         given:

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/DeleteHandlerTest.groovy
@@ -10,7 +10,7 @@ import static software.amazon.ce.costcategory.Fixtures.*
 
 class DeleteHandlerTest extends HandlerSpecification {
 
-    def handler = new DeleteHandler()
+    def handler = new DeleteHandler(TestUtils.generateTestClient())
 
     def "Test: handleRequest"() {
         given:

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ListHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ListHandlerTest.groovy
@@ -9,7 +9,7 @@ import static software.amazon.ce.costcategory.Fixtures.*
 
 class ListHandlerTest extends HandlerSpecification {
 
-    def handler = new ListHandler()
+    def handler = new ListHandler(TestUtils.generateTestClient())
 
     def "Test: handleRequest"() {
         given:

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
@@ -20,6 +20,7 @@ class ReadHandlerTest extends HandlerSpecification {
                     .effectiveStart(COST_CATEGORY_EFFECTIVE_START)
                     .ruleVersion(RULE_VERSION)
                     .rules([ RULE_DIMENSION ])
+                    .defaultValue(COST_CATEGORY_DEFAULT_VALUE)
                     .build()
             ).build()
 
@@ -41,6 +42,7 @@ class ReadHandlerTest extends HandlerSpecification {
         model.effectiveStart == COST_CATEGORY_EFFECTIVE_START
         model.ruleVersion == RULE_VERSION
         model.rules == "[ ${JSON_RULE_DIMENSION} ]"
+        model.defaultValue == COST_CATEGORY_DEFAULT_VALUE
 
         event.resourceModel == model
         event.status == OperationStatus.SUCCESS

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
@@ -9,7 +9,7 @@ import static software.amazon.ce.costcategory.Fixtures.*
 
 class ReadHandlerTest extends HandlerSpecification {
 
-    def handler = new ReadHandler()
+    def handler = new ReadHandler(TestUtils.generateTestClient())
 
     def "Test: ReadHandler.handleRequest"() {
         given:

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/TestUtils.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/TestUtils.groovy
@@ -1,0 +1,13 @@
+package software.amazon.ce.costcategory;
+
+import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+
+class TestUtils {
+
+    static CostExplorerClient generateTestClient() {
+        return CostExplorerClient.builder()
+                .httpClient(new DefaultSdkHttpClientBuilder().build())
+                .build();
+    }
+}

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/UpdateHandlerTest.groovy
@@ -8,7 +8,7 @@ import static software.amazon.ce.costcategory.Fixtures.*
 
 class UpdateHandlerTest extends HandlerSpecification {
 
-    def handler = new UpdateHandler()
+    def handler = new UpdateHandler(TestUtils.generateTestClient())
 
     def "Test: handleRequest"() {
         given:


### PR DESCRIPTION
Notes
======

This adds support for Cost Categories resource to work in multiple regions within supported partitions for Cost Categories service.

Cost Categories is currently deployed within 2 partitions, for regions within these partitions we should use the global AWS region for that partition. Add a partition to global region lookup map to use the correct endpoint for given region partition.

Also fix contract tests.

Testing
======

Deployed modified resource to personal AWS account in multiple regions and ran integration tests against the region. Regions included:
- us-east-1
- eu-west-1
- us-west-1
- ap-southeast-1
- ap-northeast-1
- us-west-2
- sa-east-1
- ap-southeast-2
- eu-central-1
- ap-northeast-2
- ap-south-1
- us-east-2
- ca-central-1
- eu-west-2
- eu-west-3
- ap-northeast-3
- eu-north-1
- ap-east-1
- me-south-1
- eu-south-1
- af-south-1
- cn-north-1
- cn-northwest-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
