### PR TITLE
Add tags-on-create to anomaly monitor and subscription resource providers

### DIFF
--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -92,6 +92,8 @@
       "items": {
         "$ref": "#/definitions/ResourceTag"
       },
+      "minItems": 0,
+      "maxItems": 200,
       "insertionOrder": false
     }
   },

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -22,7 +22,7 @@
         "Value": {
           "type": "string",
           "description": "The value for the tag.",
-          "minLength": 0,
+          "minLength": 1,
           "maxLength": 256
         }
       },

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -7,6 +7,29 @@
       "description": "Monitor ARN",
       "type": "string",
       "pattern": "^arn:aws[-a-z0-9]*:[a-z0-9]+:[-a-z0-9]*:[0-9]{12}:[-a-zA-Z0-9/:_]+$"
+    },
+    "Tag": {
+      "description": "A key-value pair to associate with a resource.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "type": "string",
+          "description": "The key name for the tag.",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "Value": {
+          "type": "string",
+          "description": "The value for the tag.",
+          "minLength": 0,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ]
     }
   },
   "properties": {
@@ -62,6 +85,14 @@
       "description": "The value for evaluated dimensions.",
       "type": "integer",
       "minimum": 0
+    },
+    "ResourceTags": {
+      "type": "array",
+      "description": "Tags to assign to monitor.",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "insertionOrder": false
     }
   },
   "additionalProperties": false,

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -13,13 +13,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ResourceTagKey": {
+        "Key": {
           "type": "string",
           "description": "The key name for the tag.",
           "minLength": 1,
           "maxLength": 128
         },
-        "ResourceTagValue": {
+        "Value": {
           "type": "string",
           "description": "The value for the tag.",
           "minLength": 0,
@@ -27,8 +27,8 @@
         }
       },
       "required": [
-        "ResourceTagKey",
-        "ResourceTagValue"
+        "Key",
+        "Value"
       ]
     }
   },
@@ -144,5 +144,12 @@
         "ce:GetAnomalyMonitors"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -149,7 +149,7 @@
     "taggable": true,
     "tagOnCreate": true,
     "tagUpdatable": false,
-    "cloudFormationSystemTags": false,
+    "cloudFormationSystemTags": true,
     "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -8,18 +8,18 @@
       "type": "string",
       "pattern": "^arn:aws[-a-z0-9]*:[a-z0-9]+:[-a-z0-9]*:[0-9]{12}:[-a-zA-Z0-9/:_]+$"
     },
-    "Tag": {
+    "ResourceTag": {
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "Key": {
+        "ResourceTagKey": {
           "type": "string",
           "description": "The key name for the tag.",
           "minLength": 1,
           "maxLength": 128
         },
-        "Value": {
+        "ResourceTagValue": {
           "type": "string",
           "description": "The value for the tag.",
           "minLength": 0,
@@ -27,8 +27,8 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "ResourceTagKey",
+        "ResourceTagValue"
       ]
     }
   },
@@ -90,7 +90,7 @@
       "type": "array",
       "description": "Tags to assign to monitor.",
       "items": {
-        "$ref": "#/definitions/Tag"
+        "$ref": "#/definitions/ResourceTag"
       },
       "insertionOrder": false
     }

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -105,7 +105,8 @@
   "createOnlyProperties": [
     "/properties/MonitorType",
     "/properties/MonitorDimension",
-    "/properties/MonitorSpecification"
+    "/properties/MonitorSpecification",
+    "/properties/ResourceTags"
   ],
   "readOnlyProperties": [
     "/properties/MonitorArn",
@@ -144,12 +145,5 @@
         "ce:GetAnomalyMonitors"
       ]
     }
-  },
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": true,
-    "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -23,7 +23,7 @@
         "Value": {
           "type": "string",
           "description": "The value for the tag.",
-          "minLength": 1,
+          "minLength": 0,
           "maxLength": 256
         }
       },

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -122,7 +122,8 @@
   "handlers": {
     "create": {
       "permissions": [
-        "ce:CreateAnomalyMonitor"
+        "ce:CreateAnomalyMonitor",
+        "ce:TagResource"
       ]
     },
     "read": {

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -16,6 +16,7 @@
         "Key": {
           "type": "string",
           "description": "The key name for the tag.",
+          "pattern": "^(?!aws:).*$",
           "minLength": 1,
           "maxLength": 128
         },

--- a/anomalymonitor/inputs/inputs_1_create.json
+++ b/anomalymonitor/inputs/inputs_1_create.json
@@ -2,5 +2,10 @@
   "MonitorName": "ContractTestMonitorName",
   "MonitorType": "DIMENSIONAL",
   "MonitorDimension": "SERVICE",
-  "ResourceTags": []
+  "ResourceTags": [
+    {
+      "Key": "TestKey",
+      "Value": "TestValue"
+    }
+  ]
 }

--- a/anomalymonitor/inputs/inputs_1_create.json
+++ b/anomalymonitor/inputs/inputs_1_create.json
@@ -1,5 +1,6 @@
 {
   "MonitorName": "ContractTestMonitorName",
   "MonitorType": "DIMENSIONAL",
-  "MonitorDimension": "SERVICE"
+  "MonitorDimension": "SERVICE",
+  "ResourceTags": []
 }

--- a/anomalymonitor/inputs/inputs_2_create.json
+++ b/anomalymonitor/inputs/inputs_2_create.json
@@ -1,5 +1,6 @@
 {
   "MonitorName": "ContractTestMonitorName",
   "MonitorType": "CUSTOM",
-  "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue1\", \"SubstituteAValidValue2\" ]\n  }\n}"
+  "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue1\", \"SubstituteAValidValue2\" ]\n  }\n}",
+  "ResourceTags": []
 }

--- a/anomalymonitor/pom.xml
+++ b/anomalymonitor/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.15.26</version>
+            <version>2.17.162</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->

--- a/anomalymonitor/resource-role.yaml
+++ b/anomalymonitor/resource-role.yaml
@@ -26,6 +26,7 @@ Resources:
                 - "ce:CreateAnomalyMonitor"
                 - "ce:DeleteAnomalyMonitor"
                 - "ce:GetAnomalyMonitors"
+                - "ce:TagResource"
                 - "ce:UpdateAnomalyMonitor"
                 Resource: "*"
 Outputs:

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Configuration.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Configuration.java
@@ -9,6 +9,10 @@ class Configuration extends BaseConfiguration {
         super("aws-ce-anomalymonitor.json");
     }
 
+    /*
+    Overrides the base method to retrieve both stack and resource tags when the getDesiredResourceTags function is called.
+     */
+    @Override
     public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
         if (resourceModel.getResourceTags() == null) {
             return null;

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Configuration.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Configuration.java
@@ -1,8 +1,19 @@
 package software.amazon.ce.anomalymonitor;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-ce-anomalymonitor.json");
+    }
+
+    public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
+        if (resourceModel.getResourceTags() == null) {
+            return null;
+        } else {
+            return resourceModel.getResourceTags().stream().collect(Collectors.toMap(ResourceTag::getKey, ResourceTag::getValue));
+        }
     }
 }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/CreateHandler.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/CreateHandler.java
@@ -34,7 +34,7 @@ public class CreateHandler extends AnomalyMonitorBaseHandler {
                     .build();
         }
         CreateAnomalyMonitorResponse response = proxy.injectCredentialsAndInvokeV2(
-                RequestBuilder.buildCreateAnomalyMonitorRequest(model),
+                RequestBuilder.buildCreateAnomalyMonitorRequest(model, request),
                 costExplorerClient::createAnomalyMonitor
         );
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -18,6 +18,7 @@ public class RequestBuilder {
 
         return CreateAnomalyMonitorRequest.builder()
                 .anomalyMonitor(anomalyMonitor)
+                .resourceTagList(model.getResourceTags())
                 .build();
     }
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -18,7 +18,7 @@ public class RequestBuilder {
 
         return CreateAnomalyMonitorRequest.builder()
                 .anomalyMonitor(anomalyMonitor)
-                .resourceTagList(model.getResourceTags())
+                .resourceTags(ResourceModelTranslator.toSDKResourceTags(model.getResourceTags()))
                 .build();
     }
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -1,18 +1,22 @@
 package software.amazon.ce.anomalymonitor;
 
 import lombok.experimental.UtilityClass;
+import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.costexplorer.model.AnomalyMonitor;
 import software.amazon.awssdk.services.costexplorer.model.Expression;
 import software.amazon.awssdk.services.costexplorer.model.CreateAnomalyMonitorRequest;
 import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalyMonitorRequest;
 import software.amazon.awssdk.services.costexplorer.model.GetAnomalyMonitorsRequest;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalyMonitorRequest;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @UtilityClass
 public class RequestBuilder {
-    public static CreateAnomalyMonitorRequest buildCreateAnomalyMonitorRequest(ResourceModel model) {
+    public static CreateAnomalyMonitorRequest buildCreateAnomalyMonitorRequest(ResourceModel model, ResourceHandlerRequest <ResourceModel> request) {
         Expression monitorSpec = model.getMonitorSpecification() != null ? Utils.toExpresionFromJson(model.getMonitorSpecification()) : null;
         AnomalyMonitor anomalyMonitor = AnomalyMonitor.builder()
                 .monitorName(model.getMonitorName())
@@ -21,9 +25,20 @@ public class RequestBuilder {
                 .monitorSpecification(monitorSpec)
                 .build();
 
+        List<ResourceTag> resourceTags = ResourceModelTranslator.toSDKResourceTags(request.getDesiredResourceTags());
+        List<ResourceTag> systemTags = ResourceModelTranslator.toSDKResourceTags(request.getSystemTags());
+
+        List<ResourceTag> tagList = new ArrayList<>();
+        if (CollectionUtils.isNotEmpty(resourceTags)) {
+            tagList.addAll(resourceTags);
+        }
+        if (CollectionUtils.isNotEmpty(systemTags)) {
+            tagList.addAll(systemTags);
+        }
+
         return CreateAnomalyMonitorRequest.builder()
                 .anomalyMonitor(anomalyMonitor)
-                .resourceTags(ResourceModelTranslator.toSDKResourceTags(model.getResourceTags()))
+                .resourceTags(tagList)
                 .build();
     }
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -23,7 +23,7 @@ public class RequestBuilder {
                 .monitorSpecification(monitorSpec)
                 .build();
 
-        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(model, request));
+        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(request));
 
         return CreateAnomalyMonitorRequest.builder()
                 .anomalyMonitor(anomalyMonitor)

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -1,7 +1,12 @@
 package software.amazon.ce.anomalymonitor;
 
 import lombok.experimental.UtilityClass;
-import software.amazon.awssdk.services.costexplorer.model.*;
+import software.amazon.awssdk.services.costexplorer.model.AnomalyMonitor;
+import software.amazon.awssdk.services.costexplorer.model.Expression;
+import software.amazon.awssdk.services.costexplorer.model.CreateAnomalyMonitorRequest;
+import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalyMonitorRequest;
+import software.amazon.awssdk.services.costexplorer.model.GetAnomalyMonitorsRequest;
+import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalyMonitorRequest;
 
 import java.util.List;
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -1,7 +1,6 @@
 package software.amazon.ce.anomalymonitor;
 
 import lombok.experimental.UtilityClass;
-import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.costexplorer.model.AnomalyMonitor;
 import software.amazon.awssdk.services.costexplorer.model.Expression;
 import software.amazon.awssdk.services.costexplorer.model.CreateAnomalyMonitorRequest;
@@ -11,7 +10,6 @@ import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalyMonitorRequest;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @UtilityClass
@@ -25,16 +23,7 @@ public class RequestBuilder {
                 .monitorSpecification(monitorSpec)
                 .build();
 
-        List<ResourceTag> resourceTags = ResourceModelTranslator.toSDKResourceTags(request.getDesiredResourceTags());
-        List<ResourceTag> systemTags = ResourceModelTranslator.toSDKResourceTags(request.getSystemTags());
-
-        List<ResourceTag> tagList = new ArrayList<>();
-        if (CollectionUtils.isNotEmpty(resourceTags)) {
-            tagList.addAll(resourceTags);
-        }
-        if (CollectionUtils.isNotEmpty(systemTags)) {
-            tagList.addAll(systemTags);
-        }
+        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(model, request));
 
         return CreateAnomalyMonitorRequest.builder()
                 .anomalyMonitor(anomalyMonitor)

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
@@ -4,6 +4,7 @@ import lombok.experimental.UtilityClass;
 import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
 public class ResourceModelTranslator {
     public static List<ResourceTag> toSDKResourceTags(Map<String, String> resourceTags) {
         if (MapUtils.isEmpty(resourceTags)) {
-            return null;
+            return Collections.emptyList();
         }
 
         return resourceTags.entrySet().stream().filter(Objects::nonNull).map(

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
@@ -1,0 +1,25 @@
+package software.amazon.ce.anomalymonitor;
+
+import lombok.experimental.UtilityClass;
+import org.apache.commons.collections.CollectionUtils;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@UtilityClass
+public class ResourceModelTranslator {
+    public static List<ResourceTag> toSDKResourceTags(List<software.amazon.ce.anomalymonitor.ResourceTag> resourceTags) {
+        if (CollectionUtils.isEmpty(resourceTags)) {
+            return null;
+        }
+
+        return resourceTags.stream().filter(Objects::nonNull).map(
+                resourceTag -> ResourceTag.builder()
+                        .key(resourceTag.getResourceTagKey())
+                        .value(resourceTag.getResourceTagValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+}

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
@@ -1,21 +1,22 @@
 package software.amazon.ce.anomalymonitor;
 
 import lombok.experimental.UtilityClass;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 @UtilityClass
 public class ResourceModelTranslator {
-    public static List<ResourceTag> toSDKResourceTags(List<software.amazon.ce.anomalymonitor.ResourceTag> resourceTags) {
-        if (CollectionUtils.isEmpty(resourceTags)) {
+    public static List<ResourceTag> toSDKResourceTags(Map<String, String> resourceTags) {
+        if (MapUtils.isEmpty(resourceTags)) {
             return null;
         }
 
-        return resourceTags.stream().filter(Objects::nonNull).map(
+        return resourceTags.entrySet().stream().filter(Objects::nonNull).map(
                 resourceTag -> ResourceTag.builder()
                         .key(resourceTag.getKey())
                         .value(resourceTag.getValue())

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
@@ -17,8 +17,8 @@ public class ResourceModelTranslator {
 
         return resourceTags.stream().filter(Objects::nonNull).map(
                 resourceTag -> ResourceTag.builder()
-                        .key(resourceTag.getResourceTagKey())
-                        .value(resourceTag.getResourceTagValue())
+                        .key(resourceTag.getKey())
+                        .value(resourceTag.getValue())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
@@ -1,0 +1,61 @@
+package software.amazon.ce.anomalymonitor;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+
+public class TagHelper {
+    /**
+     * convertToMap
+     *
+     * Converts a collection of Tag objects to a tag-name -> tag-value map.
+     *
+     * Note: Tag objects with null tag values will not be included in the output
+     * map.
+     *
+     * @param tags Collection of tags to convert
+     * @return Converted Map of tags
+     */
+    public static Map<String, String> convertToMap(final Collection<ResourceTag> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyMap();
+        }
+        return tags.stream()
+                .filter(tag -> tag.value() != null)
+                .collect(Collectors.toMap(
+                        ResourceTag::key,
+                        ResourceTag::value,
+                        (oldValue, newValue) -> newValue));
+    }
+
+    /**
+     * generateTagsForCreate
+     *
+     * Generate tags to put into resource creation request.
+     * This includes user defined tags and system tags as well.
+     */
+    public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> tagMap = new HashMap<>();
+
+        // merge system tags with desired resource tags if your service supports CloudFormation system tags
+        if (handlerRequest.getSystemTags() != null) {
+            tagMap.putAll(handlerRequest.getSystemTags());
+        }
+
+        if (handlerRequest.getDesiredResourceTags() != null) {
+            tagMap.putAll(handlerRequest.getDesiredResourceTags());
+        }
+
+        // TODO: get tags from resource model based on your tag property name
+        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
+        return Collections.unmodifiableMap(tagMap);
+    }
+
+}

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
@@ -44,17 +44,16 @@ public class TagHelper {
     public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
-        // merge system tags with desired resource tags if your service supports CloudFormation system tags
+        /* TODO Uncomment when system tags are enabled
         if (handlerRequest.getSystemTags() != null) {
             tagMap.putAll(handlerRequest.getSystemTags());
         }
+         */
 
         if (handlerRequest.getDesiredResourceTags() != null) {
             tagMap.putAll(handlerRequest.getDesiredResourceTags());
         }
 
-        // TODO: get tags from resource model based on your tag property name
-        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
         return Collections.unmodifiableMap(tagMap);
     }
 

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
@@ -1,40 +1,13 @@
 package software.amazon.ce.anomalymonitor;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
-import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 
 public class TagHelper {
-    /**
-     * convertToMap
-     *
-     * Converts a collection of Tag objects to a tag-name -> tag-value map.
-     *
-     * Note: Tag objects with null tag values will not be included in the output
-     * map.
-     *
-     * @param tags Collection of tags to convert
-     * @return Converted Map of tags
-     */
-    public static Map<String, String> convertToMap(final Collection<ResourceTag> tags) {
-        if (CollectionUtils.isEmpty(tags)) {
-            return Collections.emptyMap();
-        }
-        return tags.stream()
-                .filter(tag -> tag.value() != null)
-                .collect(Collectors.toMap(
-                        ResourceTag::key,
-                        ResourceTag::value,
-                        (oldValue, newValue) -> newValue));
-    }
-
     /**
      * generateTagsForCreate
      *
@@ -44,11 +17,9 @@ public class TagHelper {
     public static Map<String, String> generateTagsForCreate(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
-        /* TODO Uncomment when system tags are enabled
         if (handlerRequest.getSystemTags() != null) {
             tagMap.putAll(handlerRequest.getSystemTags());
         }
-         */
 
         if (handlerRequest.getDesiredResourceTags() != null) {
             tagMap.putAll(handlerRequest.getDesiredResourceTags());

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/TagHelper.java
@@ -41,7 +41,7 @@ public class TagHelper {
      * Generate tags to put into resource creation request.
      * This includes user defined tags and system tags as well.
      */
-    public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+    public static Map<String, String> generateTagsForCreate(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
         /* TODO Uncomment when system tags are enabled

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ConfigurationTest.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ConfigurationTest.java
@@ -1,0 +1,41 @@
+package software.amazon.ce.anomalymonitor;
+
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+public class ConfigurationTest {
+    @Test
+    public void handleRequest_Success_ResourceDefinedTagsExist() {
+        final Configuration configuration = new Configuration();
+
+        final ResourceModel model = ResourceModel.builder()
+                .monitorName(TestFixtures.MONITOR_NAME)
+                .monitorType(TestFixtures.MONITOR_TYPE_DIMENSIONAL)
+                .monitorArn(TestFixtures.MONITOR_ARN)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
+                .build();
+
+        final Map<String, String> resourceDefinedTags = configuration.resourceDefinedTags(model);
+
+        assertThat(resourceDefinedTags).isNotNull();
+        assertThat(resourceDefinedTags).hasSameSizeAs(TestFixtures.RESOURCE_TAGS);
+    }
+
+    @Test
+    public void handleRequest_Success_ResourceDefinedTagsEmpty() {
+        final Configuration configuration = new Configuration();
+
+        final ResourceModel model = ResourceModel.builder()
+                .monitorName(TestFixtures.MONITOR_NAME)
+                .monitorType(TestFixtures.MONITOR_TYPE_DIMENSIONAL)
+                .monitorArn(TestFixtures.MONITOR_ARN)
+                .build();
+
+        final Map<String, String> resourceDefinedTags = configuration.resourceDefinedTags(model);
+
+        assertThat(resourceDefinedTags).isNull();
+    }
+}

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ConfigurationTest.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ConfigurationTest.java
@@ -22,6 +22,9 @@ public class ConfigurationTest {
 
         assertThat(resourceDefinedTags).isNotNull();
         assertThat(resourceDefinedTags).hasSameSizeAs(TestFixtures.RESOURCE_TAGS);
+
+        assert resourceDefinedTags.containsKey(TestFixtures.RESOURCE_TAG_KEY);
+        assert resourceDefinedTags.get(TestFixtures.RESOURCE_TAG_KEY).equals(TestFixtures.RESOURCE_TAG_VALUE);
     }
 
     @Test

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/CreateHandlerTest.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/CreateHandlerTest.java
@@ -73,6 +73,7 @@ public class CreateHandlerTest {
                 .monitorName(TestFixtures.MONITOR_NAME)
                 .monitorType(TestFixtures.MONITOR_TYPE_CUSTOM)
                 .monitorSpecification(TestFixtures.TAGS_MONITOR_SPEC)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
@@ -17,4 +17,9 @@ public class TestFixtures {
     public static String DATE = "2020-11-15T00:00::00Z";
     public static String DIMENSION = "SERVICE";
     public static int DIMENSIONAL_VALUE_COUNT = 100;
+    public static List<ResourceTag> RESOURCE_TAG_LIST = Arrays.asList(ResourceTag.builder()
+            .resourceTagKey("TestResourceTagKey")
+            .resourceTagValue("TestResourceTagValue")
+            .build()
+        );
 }

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
@@ -17,7 +17,7 @@ public class TestFixtures {
     public static String DATE = "2020-11-15T00:00::00Z";
     public static String DIMENSION = "SERVICE";
     public static int DIMENSIONAL_VALUE_COUNT = 100;
-    public static List<ResourceTag> RESOURCE_TAG_LIST = Arrays.asList(ResourceTag.builder()
+    public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
             .resourceTagKey("TestResourceTagKey")
             .resourceTagValue("TestResourceTagValue")
             .build()

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
@@ -18,8 +18,8 @@ public class TestFixtures {
     public static String DIMENSION = "SERVICE";
     public static int DIMENSIONAL_VALUE_COUNT = 100;
     public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
-            .resourceTagKey("TestResourceTagKey")
-            .resourceTagValue("TestResourceTagValue")
+            .key("TestResourceTagKey")
+            .value("TestResourceTagValue")
             .build()
         );
 }

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestFixtures.java
@@ -17,9 +17,11 @@ public class TestFixtures {
     public static String DATE = "2020-11-15T00:00::00Z";
     public static String DIMENSION = "SERVICE";
     public static int DIMENSIONAL_VALUE_COUNT = 100;
+    public static String RESOURCE_TAG_KEY = "TestResourceTagKey";
+    public static String RESOURCE_TAG_VALUE = "TestResourceTagValue";
     public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
-            .key("TestResourceTagKey")
-            .value("TestResourceTagValue")
+            .key(RESOURCE_TAG_KEY)
+            .value(RESOURCE_TAG_VALUE)
             .build()
         );
 }

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -140,7 +140,8 @@
   "handlers": {
     "create": {
       "permissions": [
-        "ce:CreateAnomalySubscription"
+        "ce:CreateAnomalySubscription",
+        "ce:TagResource"
       ]
     },
     "read": {

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -165,7 +165,7 @@
     "taggable": true,
     "tagOnCreate": true,
     "tagUpdatable": false,
-    "cloudFormationSystemTags": false,
+    "cloudFormationSystemTags": true,
     "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -36,18 +36,18 @@
       ],
       "additionalProperties": false
     },
-    "Tag": {
+    "ResourceTag": {
       "description": "A key-value pair to associate with a resource.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "Key": {
+        "ResourceTagKey": {
           "type": "string",
           "description": "The key name for the tag.",
           "minLength": 1,
           "maxLength": 128
         },
-        "Value": {
+        "ResourceTagValue": {
           "type": "string",
           "description": "The value for the tag.",
           "minLength": 0,
@@ -55,8 +55,8 @@
         }
       },
       "required": [
-        "Key",
-        "Value"
+        "ResourceTagKey",
+        "ResourceTagValue"
       ]
     }
   },
@@ -111,7 +111,7 @@
       "type": "array",
       "description": "Tags to assign to monitor.",
       "items": {
-        "$ref": "#/definitions/Tag"
+        "$ref": "#/definitions/ResourceTag"
       },
       "insertionOrder": false
     }

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -126,6 +126,9 @@
     "Frequency",
     "SubscriptionName"
   ],
+  "createOnlyProperties": [
+    "/properties/ResourceTags"
+  ],
   "readOnlyProperties": [
     "/properties/SubscriptionArn",
     "/properties/AccountId",
@@ -160,12 +163,5 @@
         "ce:GetAnomalySubscriptions"
       ]
     }
-  },
-  "tagging": {
-    "taggable": true,
-    "tagOnCreate": true,
-    "tagUpdatable": false,
-    "cloudFormationSystemTags": true,
-    "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -35,6 +35,29 @@
         "Type"
       ],
       "additionalProperties": false
+    },
+    "Tag": {
+      "description": "A key-value pair to associate with a resource.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "Key": {
+          "type": "string",
+          "description": "The key name for the tag.",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "Value": {
+          "type": "string",
+          "description": "The value for the tag.",
+          "minLength": 0,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "Key",
+        "Value"
+      ]
     }
   },
   "properties": {
@@ -83,6 +106,14 @@
         "IMMEDIATE",
         "WEEKLY"
       ]
+    },
+    "ResourceTags": {
+      "type": "array",
+      "description": "Tags to assign to monitor.",
+      "items": {
+        "$ref": "#/definitions/Tag"
+      },
+      "insertionOrder": false
     }
   },
   "additionalProperties": false,

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -13,7 +13,7 @@
       "properties": {
         "Address": {
           "type": "string",
-          "pattern": "(^[a-zA-Z0-9.!#$%&'*+=?^_\u2018{|}~-]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$)|(^arn:(aws[a-zA-Z-]*):sns:[a-zA-Z0-9-]+:[0-9]{12}:[a-zA-Z0-9_-]+$)"
+          "pattern": "(^[a-zA-Z0-9.!#$%&'*+=?^_\u2018{|}~-]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$)|(^arn:(aws[a-zA-Z-]*):sns:[a-zA-Z0-9-]+:[0-9]{12}:[a-zA-Z0-9_-]+\\.fifo$)"
         },
         "Status": {
           "type": "string",

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -50,7 +50,7 @@
         "Value": {
           "type": "string",
           "description": "The value for the tag.",
-          "minLength": 0,
+          "minLength": 1,
           "maxLength": 256
         }
       },

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -113,6 +113,8 @@
       "items": {
         "$ref": "#/definitions/ResourceTag"
       },
+      "minItems": 0,
+      "maxItems": 200,
       "insertionOrder": false
     }
   },

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -110,7 +110,7 @@
     },
     "ResourceTags": {
       "type": "array",
-      "description": "Tags to assign to monitor.",
+      "description": "Tags to assign to subscription.",
       "items": {
         "$ref": "#/definitions/ResourceTag"
       },

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -41,13 +41,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ResourceTagKey": {
+        "Key": {
           "type": "string",
           "description": "The key name for the tag.",
           "minLength": 1,
           "maxLength": 128
         },
-        "ResourceTagValue": {
+        "Value": {
           "type": "string",
           "description": "The value for the tag.",
           "minLength": 0,
@@ -55,8 +55,8 @@
         }
       },
       "required": [
-        "ResourceTagKey",
-        "ResourceTagValue"
+        "Key",
+        "Value"
       ]
     }
   },
@@ -160,5 +160,12 @@
         "ce:GetAnomalySubscriptions"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": false,
+    "tagProperty": "#/properties/ResourceTags"
   }
 }

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -13,7 +13,7 @@
       "properties": {
         "Address": {
           "type": "string",
-          "pattern": "(^[a-zA-Z0-9.!#$%&'*+=?^_\u2018{|}~-]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$)|(^arn:(aws[a-zA-Z-]*):sns:[a-zA-Z0-9-]+:[0-9]{12}:[a-zA-Z0-9_-]+\\.fifo$)"
+          "pattern": "(^[a-zA-Z0-9.!#$%&'*+=?^_\u2018{|}~-]+@[a-zA-Z0-9_-]+(\\.[a-zA-Z0-9_-]+)+$)|(^arn:(aws[a-zA-Z-]*):sns:[a-zA-Z0-9-]+:[0-9]{12}:[a-zA-Z0-9_-]+(\\.fifo)?$)"
         },
         "Status": {
           "type": "string",

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -51,7 +51,7 @@
         "Value": {
           "type": "string",
           "description": "The value for the tag.",
-          "minLength": 1,
+          "minLength": 0,
           "maxLength": 256
         }
       },

--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -44,6 +44,7 @@
         "Key": {
           "type": "string",
           "description": "The key name for the tag.",
+          "pattern": "^(?!aws:).*$",
           "minLength": 1,
           "maxLength": 128
         },

--- a/anomalysubscription/inputs/inputs_1_create.json
+++ b/anomalysubscription/inputs/inputs_1_create.json
@@ -8,5 +8,6 @@
       "Type": "EMAIL"
     }
   ],
-  "Frequency": "DAILY"
+  "Frequency": "DAILY",
+  "ResourceTags": []
 }

--- a/anomalysubscription/inputs/inputs_2_create.json
+++ b/anomalysubscription/inputs/inputs_2_create.json
@@ -9,10 +9,5 @@
     }
   ],
   "Frequency": "DAILY",
-  "ResourceTags": [
-    {
-      "Key": "TestKey",
-      "Value": "TestValue"
-    }
-  ]
+  "ResourceTags": []
 }

--- a/anomalysubscription/inputs/inputs_2_invalid.json
+++ b/anomalysubscription/inputs/inputs_2_invalid.json
@@ -1,0 +1,13 @@
+{
+  "SubscriptionName": "ContractTestSubscriptionName",
+  "SubscriptionArn": "arn:aws:ce::313025035011:anomalysubscription/d79c551d-ea6b-4b90-8a9e-e5c40dc3b491",
+  "Threshold": 1,
+  "MonitorArnList": [],
+  "Subscribers": [
+    {
+      "Address": "araphn@amazon.com",
+      "Type": "EMAIL"
+    }
+  ],
+  "Frequency": "DAILY"
+}

--- a/anomalysubscription/inputs/inputs_2_update.json
+++ b/anomalysubscription/inputs/inputs_2_update.json
@@ -1,0 +1,12 @@
+{
+  "SubscriptionName": "UpdateContractTestSubscriptionName",
+  "Threshold": 1000,
+  "MonitorArnList": [],
+  "Subscribers": [
+    {
+      "Address": "tstodiec@amazon.com",
+      "Type": "EMAIL"
+    }
+  ],
+  "Frequency": "DAILY"
+}

--- a/anomalysubscription/pom.xml
+++ b/anomalysubscription/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.15.26</version>
+            <version>2.17.162</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->

--- a/anomalysubscription/resource-role.yaml
+++ b/anomalysubscription/resource-role.yaml
@@ -26,6 +26,7 @@ Resources:
                 - "ce:CreateAnomalySubscription"
                 - "ce:DeleteAnomalySubscription"
                 - "ce:GetAnomalySubscriptions"
+                - "ce:TagResource"
                 - "ce:UpdateAnomalySubscription"
                 Resource: "*"
 Outputs:

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Configuration.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Configuration.java
@@ -9,6 +9,10 @@ class Configuration extends BaseConfiguration {
         super("aws-ce-anomalysubscription.json");
     }
 
+    /*
+    Overrides the base method to retrieve both stack and resource tags when the getDesiredResourceTags function is called.
+     */
+    @Override
     public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
         if (resourceModel.getResourceTags() == null) {
             return null;

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Configuration.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Configuration.java
@@ -1,8 +1,19 @@
 package software.amazon.ce.anomalysubscription;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
         super("aws-ce-anomalysubscription.json");
+    }
+
+    public Map<String, String> resourceDefinedTags(final ResourceModel resourceModel) {
+        if (resourceModel.getResourceTags() == null) {
+            return null;
+        } else {
+            return resourceModel.getResourceTags().stream().collect(Collectors.toMap(ResourceTag::getKey, ResourceTag::getValue));
+        }
     }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/CreateHandler.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/CreateHandler.java
@@ -31,7 +31,7 @@ public class CreateHandler extends AnomalySubscriptionBaseHandler {
                     .build();
         }
         CreateAnomalySubscriptionResponse response = proxy.injectCredentialsAndInvokeV2(
-                RequestBuilder.buildCreateAnomalySubscriptionRequest(model),
+                RequestBuilder.buildCreateAnomalySubscriptionRequest(model, request),
                 costExplorerClient::createAnomalySubscription
         );
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -1,7 +1,11 @@
 package software.amazon.ce.anomalysubscription;
 
 import lombok.experimental.UtilityClass;
-import software.amazon.awssdk.services.costexplorer.model.*;
+import software.amazon.awssdk.services.costexplorer.model.AnomalySubscription;
+import software.amazon.awssdk.services.costexplorer.model.CreateAnomalySubscriptionRequest;
+import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalySubscriptionRequest;
+import software.amazon.awssdk.services.costexplorer.model.GetAnomalySubscriptionsRequest;
+import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalySubscriptionRequest;
 
 import java.util.List;
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -5,13 +5,15 @@ import software.amazon.awssdk.services.costexplorer.model.AnomalySubscription;
 import software.amazon.awssdk.services.costexplorer.model.CreateAnomalySubscriptionRequest;
 import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalySubscriptionRequest;
 import software.amazon.awssdk.services.costexplorer.model.GetAnomalySubscriptionsRequest;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalySubscriptionRequest;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.List;
 
 @UtilityClass
 public class RequestBuilder {
-    public static CreateAnomalySubscriptionRequest buildCreateAnomalySubscriptionRequest(ResourceModel model) {
+    public static CreateAnomalySubscriptionRequest buildCreateAnomalySubscriptionRequest(ResourceModel model, ResourceHandlerRequest<ResourceModel> request) {
         AnomalySubscription anomalySubscription = AnomalySubscription.builder()
                 .subscriptionName(model.getSubscriptionName())
                 .threshold(model.getThreshold())
@@ -20,9 +22,11 @@ public class RequestBuilder {
                 .subscribers(ResourceModelTranslator.toSDKSubscribers(model.getSubscribers()))
                 .build();
 
+        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(model, request));
+
         return CreateAnomalySubscriptionRequest.builder()
                 .anomalySubscription(anomalySubscription)
-                .resourceTags(ResourceModelTranslator.toSDKResourceTags(model.getResourceTags()))
+                .resourceTags(tagList)
                 .build();
     }
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -22,7 +22,7 @@ public class RequestBuilder {
                 .subscribers(ResourceModelTranslator.toSDKSubscribers(model.getSubscribers()))
                 .build();
 
-        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(model, request));
+        List<ResourceTag> tagList = ResourceModelTranslator.toSDKResourceTags(TagHelper.generateTagsForCreate(request));
 
         return CreateAnomalySubscriptionRequest.builder()
                 .anomalySubscription(anomalySubscription)

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -18,7 +18,7 @@ public class RequestBuilder {
 
         return CreateAnomalySubscriptionRequest.builder()
                 .anomalySubscription(anomalySubscription)
-                .resourceTagList(model.getResourceTags())
+                .resourceTags(ResourceModelTranslator.toSDKResourceTags(model.getResourceTags()))
                 .build();
     }
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -18,6 +18,7 @@ public class RequestBuilder {
 
         return CreateAnomalySubscriptionRequest.builder()
                 .anomalySubscription(anomalySubscription)
+                .resourceTagList(model.getResourceTags())
                 .build();
     }
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -1,24 +1,11 @@
 package software.amazon.ce.anomalysubscription;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import com.google.common.collect.ImmutableMap;
 import lombok.experimental.UtilityClass;
-import software.amazon.awssdk.services.costexplorer.model.*;
+import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.Subscriber;
-import software.amazon.awssdk.services.costexplorer.model.SubscriberType;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import org.apache.commons.collections.CollectionUtils;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -46,8 +46,8 @@ public class ResourceModelTranslator {
 
         return resourceTags.stream().filter(Objects::nonNull).map(
                 resourceTag -> ResourceTag.builder()
-                        .key(resourceTag.getResourceTagKey())
-                        .value(resourceTag.getResourceTagValue())
+                        .key(resourceTag.getKey())
+                        .value(resourceTag.getValue())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.google.common.collect.ImmutableMap;
 import lombok.experimental.UtilityClass;
 import software.amazon.awssdk.services.costexplorer.model.*;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.Subscriber;
 import software.amazon.awssdk.services.costexplorer.model.SubscriberType;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
@@ -48,6 +49,19 @@ public class ResourceModelTranslator {
                     .status(subscriber.getStatus() != null ? subscriber.getStatus().toString() : null)
                     .type(subscriber.getType() != null ? subscriber.getType().toString() : null)
                     .build())
+                .collect(Collectors.toList());
+    }
+
+    public static List<ResourceTag> toSDKResourceTags(List<software.amazon.ce.anomalysubscription.ResourceTag> resourceTags) {
+        if (CollectionUtils.isEmpty(resourceTags)) {
+            return null;
+        }
+
+        return resourceTags.stream().filter(Objects::nonNull).map(
+                resourceTag -> ResourceTag.builder()
+                        .key(resourceTag.getResourceTagKey())
+                        .value(resourceTag.getResourceTagValue())
+                        .build())
                 .collect(Collectors.toList());
     }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -2,10 +2,12 @@ package software.amazon.ce.anomalysubscription;
 
 import lombok.experimental.UtilityClass;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.Subscriber;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -39,16 +41,16 @@ public class ResourceModelTranslator {
                 .collect(Collectors.toList());
     }
 
-    public static List<ResourceTag> toSDKResourceTags(List<software.amazon.ce.anomalysubscription.ResourceTag> resourceTags) {
-        if (CollectionUtils.isEmpty(resourceTags)) {
+    public static List<ResourceTag> toSDKResourceTags(Map<String, String> resourceTags) {
+        if (MapUtils.isEmpty(resourceTags)) {
             return null;
         }
 
-        return resourceTags.stream().filter(Objects::nonNull).map(
-                resourceTag -> ResourceTag.builder()
-                        .key(resourceTag.getKey())
-                        .value(resourceTag.getValue())
-                        .build())
+        return resourceTags.entrySet().stream().filter(Objects::nonNull).map(
+                        resourceTag -> ResourceTag.builder()
+                                .key(resourceTag.getKey())
+                                .value(resourceTag.getValue())
+                                .build())
                 .collect(Collectors.toList());
     }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -6,6 +6,7 @@ import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.Subscriber;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -43,7 +44,7 @@ public class ResourceModelTranslator {
 
     public static List<ResourceTag> toSDKResourceTags(Map<String, String> resourceTags) {
         if (MapUtils.isEmpty(resourceTags)) {
-            return null;
+            return Collections.emptyList();
         }
 
         return resourceTags.entrySet().stream().filter(Objects::nonNull).map(

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
@@ -1,40 +1,13 @@
 package software.amazon.ce.anomalysubscription;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
-import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 
 public class TagHelper {
-    /**
-     * convertToMap
-     *
-     * Converts a collection of Tag objects to a tag-name -> tag-value map.
-     *
-     * Note: Tag objects with null tag values will not be included in the output
-     * map.
-     *
-     * @param tags Collection of tags to convert
-     * @return Converted Map of tags
-     */
-    public static Map<String, String> convertToMap(final Collection<ResourceTag> tags) {
-        if (CollectionUtils.isEmpty(tags)) {
-            return Collections.emptyMap();
-        }
-        return tags.stream()
-                .filter(tag -> tag.value() != null)
-                .collect(Collectors.toMap(
-                        ResourceTag::key,
-                        ResourceTag::value,
-                        (oldValue, newValue) -> newValue));
-    }
-
     /**
      * generateTagsForCreate
      *
@@ -44,11 +17,9 @@ public class TagHelper {
     public static Map<String, String> generateTagsForCreate(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
-        /* TODO Uncomment when system tags are enabled
         if (handlerRequest.getSystemTags() != null) {
             tagMap.putAll(handlerRequest.getSystemTags());
         }
-         */
 
         if (handlerRequest.getDesiredResourceTags() != null) {
             tagMap.putAll(handlerRequest.getDesiredResourceTags());

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
@@ -44,17 +44,16 @@ public class TagHelper {
     public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
-        // merge system tags with desired resource tags if your service supports CloudFormation system tags
+        /* TODO Uncomment when system tags are enabled
         if (handlerRequest.getSystemTags() != null) {
             tagMap.putAll(handlerRequest.getSystemTags());
         }
+         */
 
         if (handlerRequest.getDesiredResourceTags() != null) {
             tagMap.putAll(handlerRequest.getDesiredResourceTags());
         }
 
-        // TODO: get tags from resource model based on your tag property name
-        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
         return Collections.unmodifiableMap(tagMap);
     }
 

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
@@ -1,0 +1,61 @@
+package software.amazon.ce.anomalysubscription;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+
+
+public class TagHelper {
+    /**
+     * convertToMap
+     *
+     * Converts a collection of Tag objects to a tag-name -> tag-value map.
+     *
+     * Note: Tag objects with null tag values will not be included in the output
+     * map.
+     *
+     * @param tags Collection of tags to convert
+     * @return Converted Map of tags
+     */
+    public static Map<String, String> convertToMap(final Collection<ResourceTag> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return Collections.emptyMap();
+        }
+        return tags.stream()
+                .filter(tag -> tag.value() != null)
+                .collect(Collectors.toMap(
+                        ResourceTag::key,
+                        ResourceTag::value,
+                        (oldValue, newValue) -> newValue));
+    }
+
+    /**
+     * generateTagsForCreate
+     *
+     * Generate tags to put into resource creation request.
+     * This includes user defined tags and system tags as well.
+     */
+    public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+        final Map<String, String> tagMap = new HashMap<>();
+
+        // merge system tags with desired resource tags if your service supports CloudFormation system tags
+        if (handlerRequest.getSystemTags() != null) {
+            tagMap.putAll(handlerRequest.getSystemTags());
+        }
+
+        if (handlerRequest.getDesiredResourceTags() != null) {
+            tagMap.putAll(handlerRequest.getDesiredResourceTags());
+        }
+
+        // TODO: get tags from resource model based on your tag property name
+        // TODO: tagMap.putAll(convertToMap(resourceModel.getTags()));
+        return Collections.unmodifiableMap(tagMap);
+    }
+
+}

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/TagHelper.java
@@ -41,7 +41,7 @@ public class TagHelper {
      * Generate tags to put into resource creation request.
      * This includes user defined tags and system tags as well.
      */
-    public static Map<String, String> generateTagsForCreate(final ResourceModel resourceModel, final ResourceHandlerRequest<ResourceModel> handlerRequest) {
+    public static Map<String, String> generateTagsForCreate(final ResourceHandlerRequest<ResourceModel> handlerRequest) {
         final Map<String, String> tagMap = new HashMap<>();
 
         /* TODO Uncomment when system tags are enabled

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ConfigurationTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ConfigurationTest.java
@@ -1,0 +1,46 @@
+package software.amazon.ce.anomalysubscription;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationTest {
+    @Test
+    public void handleRequest_Success_ResourceDefinedTagsExist() {
+        final Configuration configuration = new Configuration();
+
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .threshold(TestFixtures.THRESHOLD)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
+                .build();
+
+        final Map<String, String> resourceDefinedTags = configuration.resourceDefinedTags(model);
+
+        assertThat(resourceDefinedTags).isNotNull();
+        assertThat(resourceDefinedTags).hasSameSizeAs(TestFixtures.RESOURCE_TAGS);
+    }
+
+    @Test
+    public void handleRequest_Success_ResourceDefinedTagsEmpty() {
+        final Configuration configuration = new Configuration();
+
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .threshold(TestFixtures.THRESHOLD)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .build();
+
+        final Map<String, String> resourceDefinedTags = configuration.resourceDefinedTags(model);
+
+        assertThat(resourceDefinedTags).isNull();
+    }
+}

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ConfigurationTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ConfigurationTest.java
@@ -25,6 +25,9 @@ public class ConfigurationTest {
 
         assertThat(resourceDefinedTags).isNotNull();
         assertThat(resourceDefinedTags).hasSameSizeAs(TestFixtures.RESOURCE_TAGS);
+
+        assert resourceDefinedTags.containsKey(TestFixtures.RESOURCE_TAG_KEY);
+        assert resourceDefinedTags.get(TestFixtures.RESOURCE_TAG_KEY).equals(TestFixtures.RESOURCE_TAG_VALUE);
     }
 
     @Test

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
@@ -42,6 +42,42 @@ public class CreateHandlerTest {
                 .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
                 .frequency(TestFixtures.FREQUENCY)
                 .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final CreateAnomalySubscriptionResponse mockResponse = CreateAnomalySubscriptionResponse.builder()
+                .subscriptionArn(TestFixtures.SUBSCRIPTION_ARN)
+                .build();
+
+        doReturn(mockResponse)
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_Success_tagsSubscription() {
+        final CreateHandler handler = new CreateHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .threshold(TestFixtures.THRESHOLD)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
                 .resourceTags(TestFixtures.RESOURCE_TAGS)
                 .build();
 

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
@@ -42,6 +42,7 @@ public class CreateHandlerTest {
                 .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
                 .frequency(TestFixtures.FREQUENCY)
                 .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
@@ -79,6 +80,7 @@ public class CreateHandlerTest {
                 .frequency(TestFixtures.FREQUENCY)
                 .monitorArnList(TestFixtures.MONITOR_ARNS)
                 .subscriptionArn(TestFixtures.SUBSCRIPTION_ARN)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
@@ -32,8 +32,8 @@ public class TestFixtures {
             .build();
     public static List<AnomalySubscription> anomalySubscriptions = Arrays.asList(anomalySubscription);
     public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
-            .resourceTagKey("TestResourceTagKey")
-            .resourceTagValue("TestResourceTagValue")
+            .key("TestResourceTagKey")
+            .value("TestResourceTagValue")
             .build()
     );
 }

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
@@ -31,7 +31,7 @@ public class TestFixtures {
             .frequency(FREQUENCY)
             .build();
     public static List<AnomalySubscription> anomalySubscriptions = Arrays.asList(anomalySubscription);
-    public static List<ResourceTag> RESOURCE_TAG_LIST = Arrays.asList(ResourceTag.builder()
+    public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
             .resourceTagKey("TestResourceTagKey")
             .resourceTagValue("TestResourceTagValue")
             .build()

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
@@ -31,9 +31,11 @@ public class TestFixtures {
             .frequency(FREQUENCY)
             .build();
     public static List<AnomalySubscription> anomalySubscriptions = Arrays.asList(anomalySubscription);
+    public static String RESOURCE_TAG_KEY = "TestResourceTagKey";
+    public static String RESOURCE_TAG_VALUE = "TestResourceTagValue";
     public static List<ResourceTag> RESOURCE_TAGS = Arrays.asList(ResourceTag.builder()
-            .key("TestResourceTagKey")
-            .value("TestResourceTagValue")
+            .key(RESOURCE_TAG_KEY)
+            .value(RESOURCE_TAG_VALUE)
             .build()
     );
 }

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestFixtures.java
@@ -31,4 +31,9 @@ public class TestFixtures {
             .frequency(FREQUENCY)
             .build();
     public static List<AnomalySubscription> anomalySubscriptions = Arrays.asList(anomalySubscription);
+    public static List<ResourceTag> RESOURCE_TAG_LIST = Arrays.asList(ResourceTag.builder()
+            .resourceTagKey("TestResourceTagKey")
+            .resourceTagValue("TestResourceTagValue")
+            .build()
+    );
 }


### PR DESCRIPTION
*Description of changes:*

Adds support for adding resource tags to anomaly monitors and subscriptions when creating those resources via Cloudformation templates. 

*Testing:*
Deployed tagged resources via Cloudformation templates and ran unit, contract, integration tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
