### PR TITLE
Upgrade dependencies and fix deprecated usage

### DIFF
--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
@@ -24,7 +24,7 @@ public class Utils {
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
         // Use upper case in JSON key
-        OBJECT_MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategy.UpperCamelCaseStrategy());
+        OBJECT_MAPPER.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 
         // SDK model has private field without getter/setter, make Jackson to use field directly
         OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Utils.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Utils.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.google.common.collect.ImmutableMap;
@@ -31,7 +31,7 @@ public class Utils {
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
         // Use upper case in JSON key
-        OBJECT_MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategy.UpperCamelCaseStrategy());
+        OBJECT_MAPPER.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 
         // SDK model has private field without getter/setter, make Jackson to use field directly
         OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);

--- a/costcategory/pom.xml
+++ b/costcategory/pom.xml
@@ -30,14 +30,14 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.17.21</version>
+            <version>2.18.39</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.6</version>
+            <version>[2.0.0,3.0.0)</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryParser.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryParser.java
@@ -28,7 +28,7 @@ public class CostCategoryParser {
         OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
 
         // Use upper case in JSON key
-        OBJECT_MAPPER.setPropertyNamingStrategy(new PropertyNamingStrategy.UpperCamelCaseStrategy());
+        OBJECT_MAPPER.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 
         // SDK model has private field without getter/setter, make Jackson to use field directly
         OBJECT_MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);


### PR DESCRIPTION

*Description of changes:*

- Fixed [build error](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cost-explorer/actions/runs/4409340044/jobs/7725497064) due to `com.fasterxml.jackson.databind.PropertyNamingStrategy` has been deprecated
- Upgrade cost category resource dependencies to be same as other resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
