### PR TITLE
Update AnomalyMonitor to support contract tests v2

### DIFF
--- a/anomalymonitor/.rpdk-config
+++ b/anomalymonitor/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalyMonitor",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "default",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.ce.anomalymonitor.HandlerWrapperExecutable"
 }

--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -63,7 +63,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 40,
-      "pattern": "(\\d{4}-\\d{2}-\\d{2})(T\\d{2}:\\d{2}:\\d{2}Z)?"
+      "pattern": "(\\d{4}-\\d{2}-\\d{2})(T\\d{2}:\\d{2}:\\d{2}Z)?|(NOT_EVALUATED_YET)"
     },
     "LastUpdatedDate": {
       "description": "The date when the monitor was last updated.",
@@ -112,10 +112,12 @@
   "readOnlyProperties": [
     "/properties/MonitorArn",
     "/properties/CreationDate",
-    "/properties/DimensionValueCount",
     "/properties/LastEvaluatedDate",
     "/properties/LastUpdatedDate",
     "/properties/DimensionalValueCount"
+  ],
+  "writeOnlyProperties": [
+    "/properties/ResourceTags"
   ],
   "primaryIdentifier": [
     "/properties/MonitorArn"

--- a/anomalymonitor/inputs/inputs_1_create.json
+++ b/anomalymonitor/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "ContractTestMonitorName",
+  "MonitorName": "ContractTestMonitorName1",
   "MonitorType": "DIMENSIONAL",
   "MonitorDimension": "SERVICE",
   "ResourceTags": [

--- a/anomalymonitor/inputs/inputs_1_invalid.json
+++ b/anomalymonitor/inputs/inputs_1_invalid.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "ContractTestMonitorName",
+  "MonitorName": "ContractTestMonitorName1",
   "MonitorType": "DIMENSIONAL",
   "MonitorDimension": "SERVICE",
   "CreationDate": "2020-12-15",

--- a/anomalymonitor/inputs/inputs_1_update.json
+++ b/anomalymonitor/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "UpdateContractTestMonitorName",
+  "MonitorName": "UpdateContractTestMonitorName1",
   "MonitorType": "DIMENSIONAL",
   "MonitorDimension": "SERVICE"
 }

--- a/anomalymonitor/inputs/inputs_1_update.json
+++ b/anomalymonitor/inputs/inputs_1_update.json
@@ -1,4 +1,5 @@
 {
   "MonitorName": "UpdateContractTestMonitorName",
-  "MonitorType": "DIMENSIONAL"
+  "MonitorType": "DIMENSIONAL",
+  "MonitorDimension": "SERVICE"
 }

--- a/anomalymonitor/inputs/inputs_2_create.json
+++ b/anomalymonitor/inputs/inputs_2_create.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "ContractTestMonitorName",
+  "MonitorName": "ContractTestMonitorName2",
   "MonitorType": "CUSTOM",
   "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue1\", \"SubstituteAValidValue2\" ]\n  }\n}",
   "ResourceTags": []

--- a/anomalymonitor/inputs/inputs_2_invalid.json
+++ b/anomalymonitor/inputs/inputs_2_invalid.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "ContractTestMonitorName-TAG",
+  "MonitorName": "ContractTestMonitorName2",
   "MonitorType": "CUSTOM",
   "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue11\", \"SubstituteAValidValue2\" ]\n  }\n}",
   "CreationDate": "2020-12-15",

--- a/anomalymonitor/inputs/inputs_2_update.json
+++ b/anomalymonitor/inputs/inputs_2_update.json
@@ -1,4 +1,5 @@
 {
   "MonitorName": "UpdateContractTestMonitorName-TAG",
-  "MonitorType": "CUSTOM"
+  "MonitorType": "CUSTOM",
+  "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue1\", \"SubstituteAValidValue2\" ]\n  }\n}"
 }

--- a/anomalymonitor/inputs/inputs_2_update.json
+++ b/anomalymonitor/inputs/inputs_2_update.json
@@ -1,5 +1,5 @@
 {
-  "MonitorName": "UpdateContractTestMonitorName-TAG",
+  "MonitorName": "UpdateContractTestMonitorName2",
   "MonitorType": "CUSTOM",
   "MonitorSpecification": "{\n  \"Tags\" : {\n    \"Key\" : \"aws:createdBy\",\n    \"Values\" : [ \"SubstituteAValidValue1\", \"SubstituteAValidValue2\" ]\n  }\n}"
 }

--- a/anomalymonitor/resource-role.yaml
+++ b/anomalymonitor/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-CE-AnomalyMonitor/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ListHandler.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ListHandler.java
@@ -8,10 +8,10 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import static software.amazon.ce.anomalymonitor.Utils.LAST_EVALUATED_DATE_PLACEHOLDER;
 
 public class ListHandler extends AnomalyMonitorBaseHandler {
 
@@ -41,7 +41,7 @@ public class ListHandler extends AnomalyMonitorBaseHandler {
                         .monitorName(anomalyMonitor.monitorName())
                         .creationDate(anomalyMonitor.creationDate())
                         .lastUpdatedDate(anomalyMonitor.lastUpdatedDate())
-                        .lastEvaluatedDate(anomalyMonitor.lastEvaluatedDate())
+                        .lastEvaluatedDate(anomalyMonitor.lastEvaluatedDate() != null ? anomalyMonitor.lastEvaluatedDate() : LAST_EVALUATED_DATE_PLACEHOLDER)
                         .monitorType(anomalyMonitor.monitorType().toString())
                         .monitorDimension(anomalyMonitor.monitorDimension() != null ? anomalyMonitor.monitorDimension().toString() : null)
                         .monitorSpecification(anomalyMonitor.monitorSpecification() != null ? Utils.toJson(anomalyMonitor.monitorSpecification()) : null)

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ReadHandler.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ReadHandler.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static software.amazon.ce.anomalymonitor.Utils.LAST_EVALUATED_DATE_PLACEHOLDER;
+
 public class ReadHandler extends AnomalyMonitorBaseHandler {
 
     public ReadHandler() {
@@ -49,7 +51,7 @@ public class ReadHandler extends AnomalyMonitorBaseHandler {
             model.setMonitorName(anomalyMonitor.monitorName());
             model.setCreationDate(anomalyMonitor.creationDate());
             model.setLastUpdatedDate(anomalyMonitor.lastUpdatedDate());
-            model.setLastEvaluatedDate(anomalyMonitor.lastEvaluatedDate());
+            model.setLastEvaluatedDate(anomalyMonitor.lastEvaluatedDate() != null ? anomalyMonitor.lastEvaluatedDate() : LAST_EVALUATED_DATE_PLACEHOLDER);
             model.setMonitorType(anomalyMonitor.monitorType().toString());
             model.setMonitorDimension(anomalyMonitor.monitorDimension() != null ? anomalyMonitor.monitorDimension().toString() : null);
             model.setMonitorSpecification(anomalyMonitor.monitorSpecification() != null ? Utils.toJson(anomalyMonitor.monitorSpecification()) : null);

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 @UtilityClass
 public class Utils {
+    public static final String LAST_EVALUATED_DATE_PLACEHOLDER = "NOT_EVALUATED_YET";
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static ObjectWriter objectWriter;
 

--- a/anomalysubscription/.rpdk-config
+++ b/anomalysubscription/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalySubscription",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.ce.anomalysubscription.HandlerWrapperExecutable"
 }

--- a/anomalysubscription/inputs/inputs_1_create.json
+++ b/anomalysubscription/inputs/inputs_1_create.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "ContractTestSubscriptionName",
+  "SubscriptionName": "ContractTestSubscriptionName1",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_PERCENTAGE\",\n    \"Values\" : [ \"1\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],
   "Subscribers": [

--- a/anomalysubscription/inputs/inputs_1_invalid.json
+++ b/anomalysubscription/inputs/inputs_1_invalid.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "ContractTestSubscriptionName",
+  "SubscriptionName": "ContractTestSubscriptionName1",
   "SubscriptionArn": "arn:aws:ce::313025035011:anomalysubscription/d79c551d-ea6b-4b90-8a9e-e5c40dc3b491",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_ABSOLUTE\",\n    \"Values\" : [ \"1\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],

--- a/anomalysubscription/inputs/inputs_1_update.json
+++ b/anomalysubscription/inputs/inputs_1_update.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "UpdateContractTestSubscriptionName",
+  "SubscriptionName": "UpdateContractTestSubscriptionName1",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_ABSOLUTE\",\n    \"Values\" : [ \"1000\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],
   "Subscribers": [

--- a/anomalysubscription/inputs/inputs_2_create.json
+++ b/anomalysubscription/inputs/inputs_2_create.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "ContractTestSubscriptionName",
+  "SubscriptionName": "ContractTestSubscriptionName2",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_PERCENTAGE\",\n    \"Values\" : [ \"1\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],
   "Subscribers": [

--- a/anomalysubscription/inputs/inputs_2_invalid.json
+++ b/anomalysubscription/inputs/inputs_2_invalid.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "ContractTestSubscriptionName",
+  "SubscriptionName": "ContractTestSubscriptionName2",
   "SubscriptionArn": "arn:aws:ce::313025035011:anomalysubscription/d79c551d-ea6b-4b90-8a9e-e5c40dc3b491",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_PERCENTAGE\",\n    \"Values\" : [ \"1\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],

--- a/anomalysubscription/inputs/inputs_2_update.json
+++ b/anomalysubscription/inputs/inputs_2_update.json
@@ -1,5 +1,5 @@
 {
-  "SubscriptionName": "UpdateContractTestSubscriptionName",
+  "SubscriptionName": "UpdateContractTestSubscriptionName2",
   "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_PERCENTAGE\",\n    \"Values\" : [ \"1000\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}",
   "MonitorArnList": [],
   "Subscribers": [

--- a/anomalysubscription/resource-role.yaml
+++ b/anomalysubscription/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-CE-AnomalySubscription/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy


### PR DESCRIPTION
*Description of changes:*
- Updating the AWS::CE::AnomalyMonitor resource to be compatible with contract tests v2
- The `LastEvaluatedDate` attribute is now populated with a placeholder `NOT_EVALUATED_YET` value in the Read and List handlers when the monitor has not yet performed an evaluation (updated attribute regex to support this)
  - This change was recommended to us by the CloudFormation team
- Removed non-existent `DimensionValueCount` attribute from resource definition (the real attribute is `DimensionalValueCount`)
- Updating test input files to avoid duplicate names between different test cases -- this caused the contract tests to periodically fail if they ran in parallel
- Changes to `.rpdk-config` and `resource-role.yaml` files were automatically generated when running `mvn package`

*Testing performed:*
- Ran contract tests v2 locally for AWS::CE::AnomalyMonitor and AWS::CE::AnomalySubscription

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
