### PR TITLE
upgrade runtime to java17

### DIFF
--- a/anomalymonitor/.rpdk-config
+++ b/anomalymonitor/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalyMonitor",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java21",
     "entrypoint": "software.amazon.ce.anomalymonitor.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.anomalymonitor.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/anomalymonitor/.rpdk-config
+++ b/anomalymonitor/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalyMonitor",
     "language": "java",
-    "runtime": "java21",
+    "runtime": "java17",
     "entrypoint": "software.amazon.ce.anomalymonitor.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.anomalymonitor.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/anomalymonitor/template.yml
+++ b/anomalymonitor/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalymonitor.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-anomalymonitor-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalymonitor.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-anomalymonitor-handler-1.0-SNAPSHOT.jar

--- a/anomalymonitor/template.yml
+++ b/anomalymonitor/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalymonitor.HandlerWrapper::handleRequest
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-anomalymonitor-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalymonitor.HandlerWrapper::testEntrypoint
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-anomalymonitor-handler-1.0-SNAPSHOT.jar

--- a/anomalysubscription/.rpdk-config
+++ b/anomalysubscription/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalySubscription",
     "language": "java",
-    "runtime": "java21",
+    "runtime": "java17",
     "entrypoint": "software.amazon.ce.anomalysubscription.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.anomalysubscription.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/anomalysubscription/.rpdk-config
+++ b/anomalysubscription/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::AnomalySubscription",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java21",
     "entrypoint": "software.amazon.ce.anomalysubscription.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.anomalysubscription.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/anomalysubscription/template.yml
+++ b/anomalysubscription/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalysubscription.HandlerWrapper::handleRequest
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-anomalysubscription-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalysubscription.HandlerWrapper::testEntrypoint
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-anomalysubscription-handler-1.0-SNAPSHOT.jar

--- a/anomalysubscription/template.yml
+++ b/anomalysubscription/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalysubscription.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-anomalysubscription-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.anomalysubscription.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-anomalysubscription-handler-1.0-SNAPSHOT.jar

--- a/costcategory/.rpdk-config
+++ b/costcategory/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::CostCategory",
     "language": "java",
-    "runtime": "java21",
+    "runtime": "java17",
     "entrypoint": "software.amazon.ce.costcategory.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.costcategory.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/costcategory/.rpdk-config
+++ b/costcategory/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::CE::CostCategory",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java21",
     "entrypoint": "software.amazon.ce.costcategory.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.ce.costcategory.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/costcategory/template.yml
+++ b/costcategory/template.yml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
       MemorySize: 512
 
@@ -19,6 +19,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java21
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
       MemorySize: 512

--- a/costcategory/template.yml
+++ b/costcategory/template.yml
@@ -11,7 +11,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::handleRequest
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
       MemorySize: 512
 
@@ -19,6 +19,6 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.ce.costcategory.HandlerWrapper::testEntrypoint
-      Runtime: java21
+      Runtime: java17
       CodeUri: ./target/aws-ce-costcategory-handler-1.0-SNAPSHOT.jar
       MemorySize: 512


### PR DESCRIPTION
*Description of changes:*

Upgrading Lambda runtime from `java8` (which is reaching EOL) to `java17`.

See Lambda runtime support [here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).

*Testing:*

Ran local sam tests invoking the CREATE, READ, LIST, UPDATE, and DELETE handlers on all resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
