### PR TITLE
JDK 17, dependencies upgrade and fix empty split charge rules issue

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
-    - name: Set up Python 3.8
+        java-version: 17
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Set up cloudformation-cli-java-plugin
       run: pip install cloudformation-cli-java-plugin
     - name: install and run pre-commit

--- a/anomalymonitor/pom.xml
+++ b/anomalymonitor/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.18.39</version>
+            <version>2.26.3</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
 
@@ -58,29 +58,17 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.26.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>2.26.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.spockframework</groupId>
-                <artifactId>spock-bom</artifactId>
-                <version>2.0-M1-groovy-2.5</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>
@@ -161,7 +149,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/anomalysubscription/pom.xml
+++ b/anomalysubscription/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.18.39</version>
+            <version>2.26.3</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
 
@@ -58,14 +58,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.6.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>

--- a/costcategory/pom.xml
+++ b/costcategory/pom.xml
@@ -12,8 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>costexplorer</artifactId>
-            <version>2.18.39</version>
+            <version>2.26.3</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
@@ -38,13 +38,19 @@
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
             <version>[2.0.0,3.0.0)</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-xml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
 
@@ -69,14 +75,14 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.26.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>2.26.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -86,7 +92,7 @@
             <dependency>
                 <groupId>org.spockframework</groupId>
                 <artifactId>spock-bom</artifactId>
-                <version>2.0-M1-groovy-2.5</version>
+                <version>2.4-M4-groovy-4.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -172,7 +178,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.12</version>
                 <configuration>
                     <excludes>
                         <exclude>**/BaseConfiguration*</exclude>
@@ -224,7 +230,7 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.12.1</version>
+                <version>3.0.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryParser.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CostCategoryParser.java
@@ -112,12 +112,12 @@ public class CostCategoryParser {
     /**
      * Parser list of {@link CostCategorySplitChargeRule} into JSON array string.
      */
-    public static String costCategorySplitChargeRulesToJson(List<CostCategorySplitChargeRule> rules) {
-        if (rules == null) {
+    public static String costCategorySplitChargeRulesToJson(CostCategory costCategory) {
+        if (!costCategory.hasSplitChargeRules()) {
             return null;
         }
         try {
-            return objectWriter.writeValueAsString(rules);
+            return objectWriter.writeValueAsString(costCategory.splitChargeRules());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/ReadHandler.java
@@ -45,7 +45,7 @@ public class ReadHandler extends CostCategoryBaseHandler {
             model.setEffectiveStart(costCategory.effectiveStart());
             model.setRuleVersion(costCategory.ruleVersionAsString());
             model.setRules(CostCategoryParser.costCategoryRulesToJson(costCategory.rules()));
-            model.setSplitChargeRules(CostCategoryParser.costCategorySplitChargeRulesToJson(costCategory.splitChargeRules()));
+            model.setSplitChargeRules(CostCategoryParser.costCategorySplitChargeRulesToJson(costCategory));
             model.setDefaultValue(costCategory.defaultValue());
 
             return ProgressEvent.<ResourceModel, CallbackContext>builder()

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/CostCategoryParserTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/CostCategoryParserTest.groovy
@@ -1,5 +1,6 @@
 package software.amazon.ce.costcategory
 
+import software.amazon.awssdk.services.costexplorer.model.CostCategory
 import software.amazon.awssdk.services.costexplorer.model.CostCategoryRule
 import software.amazon.awssdk.services.costexplorer.model.CostCategorySplitChargeRule
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException
@@ -7,12 +8,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static software.amazon.ce.costcategory.Fixtures.*
-import static software.amazon.ce.costcategory.Fixtures.JSON_SPLIT_CHARGE_RULE_EVEN
-import static software.amazon.ce.costcategory.Fixtures.JSON_SPLIT_CHARGE_RULE_FIXED
-import static software.amazon.ce.costcategory.Fixtures.JSON_SPLIT_CHARGE_RULE_PROPORTIONAL
-import static software.amazon.ce.costcategory.Fixtures.SPLIT_CHARGE_RULE_EVEN
-import static software.amazon.ce.costcategory.Fixtures.SPLIT_CHARGE_RULE_FIXED
-import static software.amazon.ce.costcategory.Fixtures.SPLIT_CHARGE_RULE_PROPORTIONAL
 
 class CostCategoryParserTest extends Specification {
 
@@ -85,7 +80,8 @@ class CostCategoryParserTest extends Specification {
     @Unroll
     def "Test: costCategorySplitChargeRulesToJson for #rule -> #expectedJson"(String expectedJson, CostCategorySplitChargeRule rule) {
         when:
-        def jsonArray = CostCategoryParser.costCategorySplitChargeRulesToJson([rule])
+        def costCategory = CostCategory.builder().splitChargeRules([rule]).build()
+        def jsonArray = CostCategoryParser.costCategorySplitChargeRulesToJson(costCategory)
 
         then:
         jsonArray == "[ ${expectedJson} ]"
@@ -97,9 +93,10 @@ class CostCategoryParserTest extends Specification {
         JSON_SPLIT_CHARGE_RULE_FIXED        | SPLIT_CHARGE_RULE_FIXED
     }
 
-    def "Test: costCategorySplitChargeRulesToJson when input is null"() {
+    def "Test: costCategorySplitChargeRulesToJson when cost category has empty split charge rules"() {
         when:
-        def jsonArray = CostCategoryParser.costCategorySplitChargeRulesToJson(null)
+        def costCategory = CostCategory.builder().build()
+        def jsonArray = CostCategoryParser.costCategorySplitChargeRulesToJson(costCategory)
 
         then:
         jsonArray == null

--- a/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
+++ b/costcategory/src/test/groovy/software/amazon/ce/costcategory/ReadHandlerTest.groovy
@@ -20,6 +20,7 @@ class ReadHandlerTest extends HandlerSpecification {
                     .effectiveStart(COST_CATEGORY_EFFECTIVE_START)
                     .ruleVersion(RULE_VERSION)
                     .rules([ RULE_DIMENSION ])
+                    .splitChargeRules([ SPLIT_CHARGE_RULE_EVEN ])
                     .defaultValue(COST_CATEGORY_DEFAULT_VALUE)
                     .build()
             ).build()
@@ -42,6 +43,7 @@ class ReadHandlerTest extends HandlerSpecification {
         model.effectiveStart == COST_CATEGORY_EFFECTIVE_START
         model.ruleVersion == RULE_VERSION
         model.rules == "[ ${JSON_RULE_DIMENSION} ]"
+        model.splitChargeRules == "[ ${JSON_SPLIT_CHARGE_RULE_EVEN} ]"
         model.defaultValue == COST_CATEGORY_DEFAULT_VALUE
 
         event.resourceModel == model


### PR DESCRIPTION
*Description of changes:*

- Upgrade to JDK17
- Upgrade to use Python 3.9 in pr-ci
- Upgrade dependencies AWS CE SDK, lombok, mockito, jacoco
- Fix to not set `SplitChargeRules` to empty list when there is no split charge rules.

The [cloudformation-cli-java-plugin](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/pull/432) has already upgraded to JDK 17. We also need to upgrade to avoid below build issue:

```
Error:  /home/runner/work/aws-cloudformation-resource-providers-cost-explorer/aws-cloudformation-resource-providers-cost-explorer/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java:[11,44] cannot access software.amazon.cloudformation.proxy.ResourceHandlerRequest
  bad class file: /home/runner/.m2/repository/software/amazon/cloudformation/aws-cloudformation-rpdk-java-plugin/2.1.1/aws-cloudformation-rpdk-java-plugin-2.1.1.jar(software/amazon/cloudformation/proxy/ResourceHandlerRequest.class)
    class file has wrong version 61.0, should be 52.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
``` 

In AWS Java SDK V2, `splitChargeRules` will never return `null` and we need to use `hasSplitChargeRules` to decide, see [doc](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/costexplorer/model/CostCategory.html#splitChargeRules())


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
