### PR TITLE
Update CallbackContext to extend StdCallbackContext

### DIFF
--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/CallbackContext.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/CallbackContext.java
@@ -1,23 +1,10 @@
 package software.amazon.ce.anomalymonitor;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
-/**
- * The CallbackContext will hold details about the current state of the execution.
- * When we return an IN_PROGRESS state and a CallbackContext,
- * CloudFormation will re-invoke the handler and pass the CallbackContext in with the request.
- * You can then make decisions based on what is included in the context.
- *
- * Handler have one minute timeout. All Cost Category API can be finished within one minute.
- * So we don't need the context for now. Keep it here for future usage.
- *
- * For example usage of the class, see https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html#resource-type-walkthrough-implement
- */
-@Data
-@NoArgsConstructor
-@Builder
-public class CallbackContext {
-
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+@lombok.EqualsAndHashCode(callSuper = true)
+public class CallbackContext extends StdCallbackContext {
 }

--- a/costcategory/src/main/java/software/amazon/ce/costcategory/CallbackContext.java
+++ b/costcategory/src/main/java/software/amazon/ce/costcategory/CallbackContext.java
@@ -1,23 +1,10 @@
 package software.amazon.ce.costcategory;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import software.amazon.cloudformation.proxy.StdCallbackContext;
 
-/**
- * The CallbackContext will hold details about the current state of the execution.
- * When we return an IN_PROGRESS state and a CallbackContext,
- * CloudFormation will re-invoke the handler and pass the CallbackContext in with the request.
- * You can then make decisions based on what is included in the context.
- *
- * Handler have one minute timeout. All Cost Category API can be finished within one minute.
- * So we don't need the context for now. Keep it here for future usage.
- *
- * For example usage of the class, see https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-walkthrough.html#resource-type-walkthrough-implement
- */
-@Data
-@NoArgsConstructor
-@Builder
-public class CallbackContext {
-
+@lombok.Getter
+@lombok.Setter
+@lombok.ToString
+@lombok.EqualsAndHashCode(callSuper = true)
+public class CallbackContext extends StdCallbackContext {
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Make `CallbackContext` extends `StdCallbackContext`, see new generated template [code](https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/python/rpdk/java/templates/init/shared/CallbackContext.java).

AnomalySubscription has already been using the new template, only need to update CostCategory and AnomalyMonitor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
