### PR TITLE
support reading tags for anomalymonitor

### DIFF
--- a/anomalymonitor/aws-ce-anomalymonitor.json
+++ b/anomalymonitor/aws-ce-anomalymonitor.json
@@ -116,9 +116,6 @@
     "/properties/LastUpdatedDate",
     "/properties/DimensionalValueCount"
   ],
-  "writeOnlyProperties": [
-    "/properties/ResourceTags"
-  ],
   "primaryIdentifier": [
     "/properties/MonitorArn"
   ],
@@ -131,7 +128,8 @@
     },
     "read": {
       "permissions": [
-        "ce:GetAnomalyMonitors"
+        "ce:GetAnomalyMonitors",
+        "ce:ListTagsForResource"
       ]
     },
     "update": {
@@ -149,5 +147,15 @@
         "ce:GetAnomalyMonitors"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/ResourceTags",
+    "permissions": [
+      "ce:ListTagsForResource"
+    ]
   }
 }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/AnomalyMonitorBaseHandler.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/AnomalyMonitorBaseHandler.java
@@ -1,11 +1,17 @@
 package software.amazon.ce.anomalymonitor;
 
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
 import java.util.Map;
@@ -45,5 +51,31 @@ public abstract class AnomalyMonitorBaseHandler extends BaseHandler<CallbackCont
 
     public AnomalyMonitorBaseHandler(CostExplorerClient costExplorerClient) {
         this.costExplorerClient = costExplorerClient;
+    }
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger
+    ) {
+        return handleRequest(
+            proxy,
+            request,
+            callbackContext != null ? callbackContext : new CallbackContext(),
+            proxy.newProxy(() -> costExplorerClient),
+            logger
+        );
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final ProxyClient<CostExplorerClient> proxyClient,
+        final Logger logger
+    ) {
+        throw new RuntimeException("Handler needs to implement either one of the handleRequest methods");
     }
 }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/RequestBuilder.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalyMonitorRe
 import software.amazon.awssdk.services.costexplorer.model.GetAnomalyMonitorsRequest;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalyMonitorRequest;
+import software.amazon.awssdk.services.costexplorer.model.ListTagsForResourceRequest;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.List;
@@ -51,6 +52,12 @@ public class RequestBuilder {
     public static DeleteAnomalyMonitorRequest buildDeleteAnomalyMonitorRequest(ResourceModel model) {
         return DeleteAnomalyMonitorRequest.builder()
                 .monitorArn(model.getMonitorArn())
+                .build();
+    }
+
+    public static ListTagsForResourceRequest buildListTagsForResourceRequest(ResourceModel model) {
+        return ListTagsForResourceRequest.builder()
+                .resourceArn(model.getMonitorArn())
                 .build();
     }
 }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/ResourceModelTranslator.java
@@ -24,4 +24,17 @@ public class ResourceModelTranslator {
                         .build())
                 .collect(Collectors.toList());
     }
+
+    public static List<software.amazon.ce.anomalymonitor.ResourceTag> toCFNResourceTags(List<ResourceTag> resourceTags) {
+        if (resourceTags == null) {
+            return Collections.emptyList();
+        }
+
+        return resourceTags.stream().filter(Objects::nonNull).map(
+                resourceTag -> software.amazon.ce.anomalymonitor.ResourceTag.builder()
+                        .key(resourceTag.key())
+                        .value(resourceTag.value())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
+++ b/anomalymonitor/src/main/java/software/amazon/ce/anomalymonitor/Utils.java
@@ -18,6 +18,8 @@ import java.util.Map;
 @UtilityClass
 public class Utils {
     public static final String LAST_EVALUATED_DATE_PLACEHOLDER = "NOT_EVALUATED_YET";
+    public static final String MONITOR_ALREADY_EXISTS = "Cannot create a monitor with the same monitor name as an existing monitor";
+    public static final String DIMENSIONAL_MONITOR_ALREADY_EXISTS = "Limit exceeded on dimensional spend monitor creation";
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static ObjectWriter objectWriter;
 

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ReadHandlerTest.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/ReadHandlerTest.java
@@ -3,9 +3,13 @@ package software.amazon.ce.anomalymonitor;
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.*;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,17 +17,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.doReturn;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.any;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
+    @Mock
+    private Credentials credentials;
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
@@ -31,20 +40,41 @@ public class ReadHandlerTest {
     @Mock
     private Logger logger;
 
-    private final ReadHandler handler = new ReadHandler(mock(CostExplorerClient.class));
+    @Mock
+    CostExplorerClient ceClient;
+
+    @Mock
+    ProxyClient<CostExplorerClient> proxyClient;
+
+    private ReadHandler handler;
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
+        credentials = new Credentials("accessKey", "secretKey", "sessionToken");
         logger = mock(Logger.class);
+        proxy = new AmazonWebServicesClientProxy(new LoggerProxy(), credentials, () -> Duration.ofSeconds(600).toMillis());
+        ceClient = mock(CostExplorerClient.class);
+        proxyClient = TestUtils.MOCK_PROXY(proxy, ceClient);
+
+        handler = new ReadHandler(ceClient);
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ResourceModel model = ResourceModel.builder().monitorArn(TestFixtures.MONITOR_ARN).build();
+        final ResourceModel expectedModel = ResourceModel.builder()
+            .monitorArn(TestFixtures.MONITOR_ARN)
+            .monitorName(TestFixtures.MONITOR_NAME)
+            .creationDate(TestFixtures.DATE)
+            .lastUpdatedDate(TestFixtures.DATE)
+            .lastEvaluatedDate(TestFixtures.DATE)
+            .monitorType(TestFixtures.MONITOR_TYPE_DIMENSIONAL)
+            .monitorDimension(TestFixtures.DIMENSION)
+            .dimensionalValueCount(TestFixtures.DIMENSIONAL_VALUE_COUNT)
+            .resourceTags(TestFixtures.RESOURCE_TAGS)
+            .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-            .desiredResourceState(model)
+            .desiredResourceState(ResourceModel.builder().monitorArn(TestFixtures.MONITOR_ARN).build())
             .build();
 
         List<AnomalyMonitor> mockMonitors = Stream.of(AnomalyMonitor.builder()
@@ -63,18 +93,70 @@ public class ReadHandlerTest {
                 .build();
 
         doReturn(mockResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+                .when(proxyClient.client()).getAnomalyMonitors(any(GetAnomalyMonitorsRequest.class));
+
+        final ListTagsForResourceResponse listTagsResponse = ListTagsForResourceResponse.builder()
+                .resourceTags(Arrays.asList(software.amazon.awssdk.services.costexplorer.model.ResourceTag.builder()
+                    .key(TestFixtures.RESOURCE_TAG_KEY)
+                    .value(TestFixtures.RESOURCE_TAG_VALUE)
+                    .build()))
+                .build();
+
+        doReturn(listTagsResponse)
+                .when(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-            = handler.handleRequest(proxy, request, null, logger);
+            = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_emptyResponse() {
+        final ResourceModel model = ResourceModel.builder().monitorArn(TestFixtures.MONITOR_ARN).build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        final GetAnomalyMonitorsResponse mockResponse = GetAnomalyMonitorsResponse.builder()
+                .anomalyMonitors(new ArrayList<>())
+                .build();
+
+        doReturn(mockResponse)
+                .when(proxyClient.client()).getAnomalyMonitors(any(GetAnomalyMonitorsRequest.class));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
+    }
+
+    @Test
+    public void handleRequest_unknownMonitorException() {
+        final ResourceModel model = ResourceModel.builder().monitorArn(TestFixtures.MONITOR_ARN).build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+
+        doThrow(UnknownMonitorException.class)
+                .when(proxyClient.client()).getAnomalyMonitors(any(GetAnomalyMonitorsRequest.class));
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+            = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
     }
 }

--- a/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestUtils.java
+++ b/anomalymonitor/src/test/java/software/amazon/ce/anomalymonitor/TestUtils.java
@@ -1,0 +1,59 @@
+package software.amazon.ce.anomalymonitor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProxyClient;
+
+public class TestUtils {
+    public static ProxyClient<CostExplorerClient> MOCK_PROXY(
+        final AmazonWebServicesClientProxy proxy,
+        final CostExplorerClient sdkClient
+    ) {
+        return new ProxyClient<CostExplorerClient>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT
+            injectCredentialsAndInvokeV2(RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+            CompletableFuture<ResponseT>
+            injectCredentialsAndInvokeV2Async(RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>>
+            IterableT
+            injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT>
+            injectCredentialsAndInvokeV2InputStream(RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT>
+            injectCredentialsAndInvokeV2Bytes(RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public CostExplorerClient client() {
+                return sdkClient;
+            }
+        };
+    }
+}


### PR DESCRIPTION
*Description of changes:*
- Adding `tagging` schema property to `AWS::CE::AnomalyMonitor`
- As part of that, `ResourceTags` can no longer be write-only, so including it in the Read handler response
- Also including small updates to Create handler to fix contract test failures
- Similar PR for `AWS::CE::AnomalySubscription` to follow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
