### PR TITLE
support reading tags for anomalysubscription

### DIFF
--- a/anomalysubscription/aws-ce-anomalysubscription.json
+++ b/anomalysubscription/aws-ce-anomalysubscription.json
@@ -138,9 +138,6 @@
     "/properties/AccountId",
     "/properties/Subscribers/*/Status"
   ],
-  "writeOnlyProperties": [
-    "/properties/ResourceTags"
-  ],
   "primaryIdentifier": [
     "/properties/SubscriptionArn"
   ],
@@ -153,7 +150,8 @@
     },
     "read": {
       "permissions": [
-        "ce:GetAnomalySubscriptions"
+        "ce:GetAnomalySubscriptions",
+        "ce:ListTagsForResource"
       ]
     },
     "update": {
@@ -171,5 +169,15 @@
         "ce:GetAnomalySubscriptions"
       ]
     }
+  },
+  "tagging": {
+    "taggable": true,
+    "tagOnCreate": true,
+    "tagUpdatable": false,
+    "cloudFormationSystemTags": true,
+    "tagProperty": "/properties/ResourceTags",
+    "permissions": [
+      "ce:ListTagsForResource"
+    ]
   }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/AnomalySubscriptionBaseHandler.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/AnomalySubscriptionBaseHandler.java
@@ -1,11 +1,17 @@
 package software.amazon.ce.anomalysubscription;
 
 import software.amazon.awssdk.core.internal.http.loader.DefaultSdkHttpClientBuilder;
+import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.utils.AttributeMap;
 import software.amazon.awssdk.utils.ImmutableMap;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.time.Duration;
 import java.util.Map;
@@ -45,5 +51,31 @@ public abstract class AnomalySubscriptionBaseHandler extends BaseHandler<Callbac
 
     public AnomalySubscriptionBaseHandler(CostExplorerClient costExplorerClient) {
         this.costExplorerClient = costExplorerClient;
+    }
+
+    @Override
+    public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final Logger logger
+    ) {
+        return handleRequest(
+            proxy,
+            request,
+            callbackContext != null ? callbackContext : new CallbackContext(),
+            proxy.newProxy(() -> costExplorerClient),
+            logger
+        );
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+        final AmazonWebServicesClientProxy proxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final CallbackContext callbackContext,
+        final ProxyClient<CostExplorerClient> proxyClient,
+        final Logger logger
+    ) {
+        throw new RuntimeException("Handler needs to implement either one of the handleRequest methods");
     }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/RequestBuilder.java
@@ -5,6 +5,7 @@ import software.amazon.awssdk.services.costexplorer.model.AnomalySubscription;
 import software.amazon.awssdk.services.costexplorer.model.CreateAnomalySubscriptionRequest;
 import software.amazon.awssdk.services.costexplorer.model.DeleteAnomalySubscriptionRequest;
 import software.amazon.awssdk.services.costexplorer.model.GetAnomalySubscriptionsRequest;
+import software.amazon.awssdk.services.costexplorer.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.costexplorer.model.ResourceTag;
 import software.amazon.awssdk.services.costexplorer.model.UpdateAnomalySubscriptionRequest;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -60,6 +61,12 @@ public class RequestBuilder {
     public static DeleteAnomalySubscriptionRequest buildDeleteAnomalySubscriptionRequest(ResourceModel model) {
         return DeleteAnomalySubscriptionRequest.builder()
                 .subscriptionArn(model.getSubscriptionArn())
+                .build();
+    }
+
+    public static ListTagsForResourceRequest buildListTagsForResourceRequest(ResourceModel model) {
+        return ListTagsForResourceRequest.builder()
+                .resourceArn(model.getSubscriptionArn())
                 .build();
     }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/ResourceModelTranslator.java
@@ -54,4 +54,17 @@ public class ResourceModelTranslator {
                                 .build())
                 .collect(Collectors.toList());
     }
+
+    public static List<software.amazon.ce.anomalysubscription.ResourceTag> toCFNResourceTags(List<ResourceTag> resourceTags) {
+        if (resourceTags == null) {
+            return Collections.emptyList();
+        }
+
+        return resourceTags.stream().filter(Objects::nonNull).map(
+                resourceTag -> software.amazon.ce.anomalysubscription.ResourceTag.builder()
+                        .key(resourceTag.key())
+                        .value(resourceTag.value())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Utils.java
+++ b/anomalysubscription/src/main/java/software/amazon/ce/anomalysubscription/Utils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 @UtilityClass
 public class Utils {
+    public static final String SUBSCRIPTION_ALREADY_EXISTS = "Cannot create a subscription with the same subscription name as an existing subscription";
     static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     static ObjectWriter objectWriter;
 

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/CreateHandlerTest.java
@@ -1,8 +1,11 @@
 package software.amazon.ce.anomalysubscription;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
 import software.amazon.awssdk.services.costexplorer.model.CreateAnomalySubscriptionResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -15,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.doReturn;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest {
@@ -165,5 +170,87 @@ public class CreateHandlerTest {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).isNotNull();
         assertThat(response.getErrorCode()).isNotNull();
+    }
+
+    @Test
+    public void handleRequest_Fail_SubscriptionAlreadyExists() {
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .thresholdExpression(TestFixtures.THRESHOLD_EXPRESSION)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final AwsServiceException exception = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorMessage(Utils.SUBSCRIPTION_ALREADY_EXISTS)
+                        .build())
+                .build();
+
+        doThrow(exception)
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = handler.handleRequest(proxy, request, null, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+    }
+
+    @Test
+    public void handleRequest_Fail_AwsServiceException() {
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .thresholdExpression(TestFixtures.THRESHOLD_EXPRESSION)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final AwsServiceException exception = AwsServiceException.builder()
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorMessage("Some other error message")
+                        .build())
+                .build();
+
+        doThrow(exception)
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+        assertThatThrownBy(() -> handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(AwsServiceException.class)
+                .hasMessageContaining("Some other error message");
+    }
+
+    @Test
+    public void handleRequest_Fail_RuntimeException() {
+        final ResourceModel model = ResourceModel.builder()
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .thresholdExpression(TestFixtures.THRESHOLD_EXPRESSION)
+                .subscribers(TestFixtures.CFN_MODEL_SUBSCRIBERS)
+                .frequency(TestFixtures.FREQUENCY)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final RuntimeException exception = new RuntimeException("error");
+
+        doThrow(exception)
+                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+
+        assertThatThrownBy(() -> handler.handleRequest(proxy, request, null, logger))
+                .isInstanceOf(RuntimeException.class);
     }
 }

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ReadHandlerTest.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/ReadHandlerTest.java
@@ -1,12 +1,23 @@
 package software.amazon.ce.anomalysubscription;
 
 import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.awssdk.services.costexplorer.model.GetAnomalySubscriptionsRequest;
 import software.amazon.awssdk.services.costexplorer.model.GetAnomalySubscriptionsResponse;
+import software.amazon.awssdk.services.costexplorer.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.costexplorer.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.costexplorer.model.UnknownSubscriptionException;
+import software.amazon.awssdk.services.costexplorer.model.Dimension;
+import software.amazon.awssdk.services.costexplorer.model.DimensionValues;
+import software.amazon.awssdk.services.costexplorer.model.Expression;
+import software.amazon.awssdk.services.costexplorer.model.MatchOption;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.Credentials;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,9 +34,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.time.Duration;
+import java.util.ArrayList;
 
 @ExtendWith(MockitoExtension.class)
 public class ReadHandlerTest {
+    @Mock
+    private Credentials credentials;
 
     @Mock
     private AmazonWebServicesClientProxy proxy;
@@ -33,23 +50,45 @@ public class ReadHandlerTest {
     @Mock
     private Logger logger;
 
+    @Mock
+    CostExplorerClient ceClient;
 
-    private final ReadHandler handler = new ReadHandler(mock(CostExplorerClient.class));
+    @Mock
+    ProxyClient<CostExplorerClient> proxyClient;
+
+    private ReadHandler handler;
 
     @BeforeEach
     public void setup() {
-        proxy = mock(AmazonWebServicesClientProxy.class);
+        credentials = new Credentials("accessKey", "secretKey", "sessionToken");
         logger = mock(Logger.class);
+        proxy = new AmazonWebServicesClientProxy(new LoggerProxy(), credentials, () -> Duration.ofSeconds(600).toMillis());
+        ceClient = mock(CostExplorerClient.class);
+        proxyClient = TestUtils.MOCK_PROXY(proxy, ceClient);
+
+        handler = new ReadHandler(ceClient);
     }
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final ResourceModel model = ResourceModel.builder()
+        final ResourceModel expectedModel = ResourceModel.builder()
                 .subscriptionArn(TestFixtures.SUBSCRIPTION_ARN)
+                .subscriptionName(TestFixtures.SUBSCRIPTION_NAME)
+                .monitorArnList(TestFixtures.MONITOR_ARNS)
+                .thresholdExpression(Utils.toJson(Expression.builder()
+                    .dimensions(DimensionValues.builder()
+                            .key(Dimension.ANOMALY_TOTAL_IMPACT_PERCENTAGE)
+                            .matchOptions(Collections.singletonList(MatchOption.GREATER_THAN_OR_EQUAL))
+                            .values(Collections.singletonList("100"))
+                            .build())
+                    .build()))
+                .subscribers(ResourceModelTranslator.toSubscribers(TestFixtures.SUBSCRIBERS))
+                .frequency(TestFixtures.FREQUENCY)
+                .resourceTags(TestFixtures.RESOURCE_TAGS)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model)
+                .desiredResourceState(ResourceModel.builder().subscriptionArn(TestFixtures.SUBSCRIPTION_ARN).build())
                 .build();
 
         final GetAnomalySubscriptionsResponse mockResponse = GetAnomalySubscriptionsResponse.builder()
@@ -57,16 +96,26 @@ public class ReadHandlerTest {
                 .build();
 
         doReturn(mockResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+                .when(proxyClient.client()).getAnomalySubscriptions(any(GetAnomalySubscriptionsRequest.class));
+
+        final ListTagsForResourceResponse listTagsResponse = ListTagsForResourceResponse.builder()
+                .resourceTags(Arrays.asList(software.amazon.awssdk.services.costexplorer.model.ResourceTag.builder()
+                    .key(TestFixtures.RESOURCE_TAG_KEY)
+                    .value(TestFixtures.RESOURCE_TAG_VALUE)
+                    .build()))
+                .build();
+
+        doReturn(listTagsResponse)
+                .when(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModel()).isEqualTo(expectedModel);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -74,19 +123,15 @@ public class ReadHandlerTest {
 
     @Test
     public void handleRequest_Failure_Read() {
-        final ResourceModel model = ResourceModel.builder()
-                .subscriptionArn(TestFixtures.SUBSCRIPTION_ARN)
-                .build();
-
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model)
+                .desiredResourceState(ResourceModel.builder().subscriptionArn(TestFixtures.SUBSCRIPTION_ARN).build())
                 .build();
 
         doThrow(UnknownSubscriptionException.class)
-                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+                .when(proxyClient.client()).getAnomalySubscriptions(any(GetAnomalySubscriptionsRequest.class));
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
@@ -98,12 +143,8 @@ public class ReadHandlerTest {
 
     @Test
     public void handleRequest_emptyResponse() {
-        final ResourceModel model = ResourceModel.builder()
-                .subscriptionArn(TestFixtures.SUBSCRIPTION_ARN)
-                .build();
-
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model)
+                .desiredResourceState(ResourceModel.builder().subscriptionArn(TestFixtures.SUBSCRIPTION_ARN).build())
                 .build();
 
         final GetAnomalySubscriptionsResponse mockResponse = GetAnomalySubscriptionsResponse.builder()
@@ -111,10 +152,10 @@ public class ReadHandlerTest {
                 .build();
 
         doReturn(mockResponse)
-                .when(proxy).injectCredentialsAndInvokeV2(any(), any());
+                .when(proxyClient.client()).getAnomalySubscriptions(any(GetAnomalySubscriptionsRequest.class));
 
         final ProgressEvent<ResourceModel, CallbackContext> response
-                = handler.handleRequest(proxy, request, null, logger);
+                = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);

--- a/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestUtils.java
+++ b/anomalysubscription/src/test/java/software/amazon/ce/anomalysubscription/TestUtils.java
@@ -1,0 +1,59 @@
+package software.amazon.ce.anomalysubscription;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import software.amazon.awssdk.awscore.AwsRequest;
+import software.amazon.awssdk.awscore.AwsResponse;
+import software.amazon.awssdk.core.SdkClient;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient;
+import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.ProxyClient;
+
+public class TestUtils {
+    public static ProxyClient<CostExplorerClient> MOCK_PROXY(
+        final AmazonWebServicesClientProxy proxy,
+        final CostExplorerClient sdkClient
+    ) {
+        return new ProxyClient<CostExplorerClient>() {
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseT
+            injectCredentialsAndInvokeV2(RequestT request, Function<RequestT, ResponseT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse>
+            CompletableFuture<ResponseT>
+            injectCredentialsAndInvokeV2Async(RequestT request, Function<RequestT, CompletableFuture<ResponseT>> requestFunction) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse, IterableT extends SdkIterable<ResponseT>>
+            IterableT
+            injectCredentialsAndInvokeIterableV2(RequestT request, Function<RequestT, IterableT> requestFunction) {
+                return proxy.injectCredentialsAndInvokeIterableV2(request, requestFunction);
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseInputStream<ResponseT>
+            injectCredentialsAndInvokeV2InputStream(RequestT requestT, Function<RequestT, ResponseInputStream<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public <RequestT extends AwsRequest, ResponseT extends AwsResponse> ResponseBytes<ResponseT>
+            injectCredentialsAndInvokeV2Bytes(RequestT requestT, Function<RequestT, ResponseBytes<ResponseT>> function) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public CostExplorerClient client() {
+                return sdkClient;
+            }
+        };
+    }
+}


### PR DESCRIPTION
*Description of changes:*
- Similar to [this PR for `AWS::CE::AnomalyMonitor`](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-cost-explorer/pull/36), this new PR is for `AWS::CE::AnomalySubscription`
- See above PR for more details


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
