### PR TITLE
Remove input folder from costcategory

### DIFF
--- a/costcategory/inputs/inputs_1_create.json
+++ b/costcategory/inputs/inputs_1_create.json
@@ -1,7 +1,0 @@
-{
-  "Name": "ContractTestCCV2",
-  "RuleVersion": "CostCategoryExpression.v1",
-  "Rules": "[ {\n  \"Value\" : \"Engineering\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n}, {\n  \"Value\" : \"HR\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789013\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n} ]",
-  "SplitChargeRules": "[ {\n  \"Source\" : \"Others\",\n  \"Targets\" : [ \"Engineering\", \"HR\" ],\n  \"Method\" : \"FIXED\",\n  \"Parameters\" : [ {\n    \"Type\" : \"ALLOCATION_PERCENTAGES\",\n    \"Values\" : [ \"50\", \"50\" ]\n  } ]\n} ]",
-  "DefaultValue": "Others"
-}

--- a/costcategory/inputs/inputs_1_invalid.json
+++ b/costcategory/inputs/inputs_1_invalid.json
@@ -1,6 +1,0 @@
-{
-  "Arn": "arn:aws:ce::494077034435:costcategory/123",
-  "Name": "ContractTestCCV2",
-  "RuleVersion": "CostCategoryExpression.v1",
-  "Rules": ""
-}

--- a/costcategory/inputs/inputs_1_update.json
+++ b/costcategory/inputs/inputs_1_update.json
@@ -1,7 +1,0 @@
-{
-  "Name": "ContractTestCCV2",
-  "RuleVersion": "CostCategoryExpression.v1",
-  "Rules": "[ {\n  \"Value\" : \"Dev\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789012\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n}, {\n  \"Value\" : \"HR\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"LINKED_ACCOUNT\",\n      \"Values\" : [ \"123456789013\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n} ]",
-  "SplitChargeRules": "[ {\n  \"Source\" : \"Others\",\n  \"Targets\" : [ \"Dev\", \"HR\" ],\n  \"Method\" : \"FIXED\",\n  \"Parameters\" : [ {\n    \"Type\" : \"ALLOCATION_PERCENTAGES\",\n    \"Values\" : [ \"80\", \"20\" ]\n  } ]\n} ]",
-  "DefaultValue": "Others"
-}


### PR DESCRIPTION
*Description of changes:*

Removing the inputs folder from the costcategory folder, as they are not needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.